### PR TITLE
Collect coverage only once.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,14 +22,8 @@ jobs:
           - git clone --depth=50 https://github.com/SUSE/shaptools.git ../shaptools
           - pip install ../salt
           - pip install ../shaptools
-      before_script:
-          - curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
-          - chmod +x ./cc-test-reporter
-          - ./cc-test-reporter before-build
       script:
           - ./tests/run.sh
-      after_script:
-          - ./cc-test-reporter after-build -t coverage.py --exit-code $TRAVIS_TEST_RESULT -p $(readlink -f ../salt)
 
     - stage: test
       python: 3.6


### PR DESCRIPTION
To avoid errors on the codeclimate execution.