### PR TITLE
Functionality to reduce HANA memory resources

### DIFF
--- a/salt/modules/hanamod.py
+++ b/salt/modules/hanamod.py
@@ -678,3 +678,131 @@ def sr_cleanup(
         hana_inst.sr_cleanup(force)
     except hana.HanaError as err:
         raise exceptions.CommandExecutionError(err)
+
+
+def set_ini_parameter(
+        ini_parameter_values,
+        database,
+        file_name,
+        layer,
+        layer_name=None,
+        reconfig=False,
+        key_name=None,
+        user_name=None,
+        user_password=None,
+        sid=None,
+        inst=None,
+        password=None):
+    '''
+    Update HANA ini configuration parameter
+
+    key_name or user_name/user_password combination,
+    one of them must be provided
+
+    ini_parameter_values
+        List containing HANA parameter details where each entry looks like:
+        {'section_name':'name', 'parameter_name':'param_name', 'parameter_value':'value'}
+    database
+        Database name
+    file_name
+        INI configuration file name
+    layer
+        Target layer for the configuration change
+    layer_name
+        Target either a tenant name or a host name(optional)
+    reconfig
+        If apply changes to running HANA instance(optional)
+    key_name
+        Keystore to connect to sap hana db
+    user_name
+        User to connect to sap hana db
+    user_password
+        Password to connecto to sap hana db
+    sid
+        HANA system id (PRD for example)
+    inst
+        HANA instance number (00 for example)
+    password
+        HANA instance password
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' hana.set_ini_parameter '[{"section_name":"memorymanager",
+        "parameter_name":"global_allocation_limit", "parameter_value":"26000"}]'
+        SYSTEMDB global.ini HOST node01 key prd '"00"' pass
+    '''
+    hana_inst = _init(sid, inst, password)
+    try:
+        hana_inst.set_ini_parameter(
+            ini_parameter_values=ini_parameter_values,database=database,
+            file_name=file_name, layer=layer,
+            layer_name=layer_name, reconfig=reconfig,
+            key_name=key_name, user_name=user_name, user_password=user_password)
+    except hana.HanaError as err:
+        raise exceptions.CommandExecutionError(err)
+
+
+def unset_ini_parameter(
+        ini_parameter_names,
+        database,
+        file_name,
+        layer,
+        layer_name=None,
+        reconfig=False,
+        key_name=None,
+        user_name=None,
+        user_password=None,
+        sid=None,
+        inst=None,
+        password=None):
+    '''
+    Update HANA ini configuration parameter
+
+    key_name or user_name/user_password combination,
+    one of them must be provided
+
+    ini_parameter_names: 
+        List of HANA parameter names where each entry looks like
+        {'section_name':'name', 'parameter_name':'param_name'}
+    database
+        Database name
+    file_name
+        INI configuration file name
+    layer
+        Target layer for the configuration change
+    layer_name
+        Target either a tenant name or a host name(optional)
+    reconfig
+        If apply changes to running HANA instance(optional)
+    key_name
+        Keystore to connect to sap hana db
+    user_name
+        User to connect to sap hana db
+    user_password
+        Password to connecto to sap hana db
+    sid
+        HANA system id (PRD for example)
+    inst
+        HANA instance number (00 for example)
+    password
+        HANA instance password
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' hana.unset_ini_parameter '[{"section_name":"memorymanager",
+        "parameter_name":"global_allocation_limit"}]'
+        SYSTEMDB global.ini SYSTEM key prd '"00"' pass
+    '''
+    hana_inst = _init(sid, inst, password)
+    try:
+        hana_inst.unset_ini_parameter(
+            ini_parameter_names=ini_parameter_names, database=database,
+            file_name=file_name, layer=layer,
+            layer_name=layer_name, reconfig=reconfig,
+            key_name=key_name, user_name=user_name, user_password=user_password)
+    except hana.HanaError as err:
+        raise exceptions.CommandExecutionError(err)

--- a/tests/unit/modules/test_hanamod.py
+++ b/tests/unit/modules/test_hanamod.py
@@ -617,3 +617,109 @@ class HanaModuleTest(TestCase, LoaderModuleMockMixin):
             mock_hana.assert_called_once_with('prd', '00', 'pass')
             mock_hana_inst.sr_cleanup.assert_called_once_with(False)
             assert 'hana error' in str(err)
+
+    def test_set_ini_parameter_return(self):
+        '''
+        Test set_ini_parameter method - return
+        '''
+        mock_hana_inst = MagicMock()
+        mock_hana = MagicMock(return_value=mock_hana_inst)
+        ini_parameter_values = [{'section_name': 'memorymanager',
+                                 'parameter_name': 'global_allocation_limit',
+                                 'parameter_value': '25000'}]
+        with patch.object(hanamod, '_init', mock_hana):
+            hanamod.set_ini_parameter(ini_parameter_values=ini_parameter_values,
+                                      database='db', file_name='global.ini',
+                                      layer='SYSTEM', layer_name=None,
+                                      reconfig=True, key_name='key',
+                                      user_name='key_user',
+                                      user_password='key_password',
+                                      sid='prd', inst='00', password='pass')
+            mock_hana.assert_called_once_with('prd', '00', 'pass')
+            mock_hana_inst.set_ini_parameter.assert_called_once_with(
+                ini_parameter_values=[{'section_name': 'memorymanager',
+                                       'parameter_name': 'global_allocation_limit',
+                                       'parameter_value': '25000'}],
+                database='db', file_name='global.ini',
+                layer='SYSTEM', layer_name=None, reconfig=True,
+                key_name='key', user_name='key_user', user_password='key_password')
+
+    def test_set_ini_parameter_raise(self):
+        '''
+        Test set_ini_parameter method - raise
+        '''
+        mock_hana_inst = MagicMock()
+        mock_hana_inst.set_ini_parameter.side_effect = hanamod.hana.HanaError(
+            'hana error'
+        )
+        mock_hana = MagicMock(return_value=mock_hana_inst)
+        ini_parameter_values = [{'section_name': 'memorymanager',
+                                 'parameter_name': 'global_allocation_limit',
+                                 'parameter_value': '25000'}]
+        with patch.object(hanamod, '_init', mock_hana):
+            with pytest.raises(exceptions.CommandExecutionError) as err:
+                hanamod.set_ini_parameter(
+                    ini_parameter_values=ini_parameter_values,
+                    database='db', file_name='global.ini', layer='SYSTEM',
+                    layer_name=None, reconfig=True, key_name='key',
+                    user_name='key_user', user_password='key_password',
+                    sid='prd', inst='00', password='pass')
+            mock_hana.assert_called_once_with('prd', '00', 'pass')
+            mock_hana_inst.set_ini_parameter.assert_called_once_with(
+                ini_parameter_values=[{'section_name': 'memorymanager',
+                                       'parameter_name': 'global_allocation_limit',
+                                       'parameter_value': '25000'}],
+                database='db', file_name='global.ini',
+                layer='SYSTEM', layer_name=None, reconfig=True,
+                key_name='key', user_name='key_user', user_password='key_password')
+            assert 'hana error' in str(err)
+
+    def test_unset_ini_parameter_return(self):
+        '''
+        Test unset_ini_parameter method - return
+        '''
+        mock_hana_inst = MagicMock()
+        mock_hana = MagicMock(return_value=mock_hana_inst)
+        with patch.object(hanamod, '_init', mock_hana):
+            hanamod.unset_ini_parameter(
+                ini_parameter_names=[{'section_name': 'memorymanager',
+                                      'parameter_name': 'global_allocation_limit'}],
+                database='db', file_name='global.ini', layer='SYSTEM',
+                layer_name=None, reconfig=True, key_name='key',
+                user_name='key_user', user_password='key_password',
+                sid='prd', inst='00', password='pass')
+            mock_hana.assert_called_once_with('prd', '00', 'pass')
+            mock_hana_inst.unset_ini_parameter.assert_called_once_with(
+                ini_parameter_names=[{'section_name': 'memorymanager',
+                                      'parameter_name': 'global_allocation_limit'}],
+                database='db', file_name='global.ini',
+                layer='SYSTEM', layer_name=None, reconfig=True,
+                key_name='key', user_name='key_user', user_password='key_password')
+
+    def test_unset_ini_parameter_raise(self):
+        '''
+        Test unset_ini_parameter method - raise
+        '''
+        mock_hana_inst = MagicMock()
+        mock_hana_inst.unset_ini_parameter.side_effect = hanamod.hana.HanaError(
+            'hana error'
+        )
+        mock_hana = MagicMock(return_value=mock_hana_inst)
+        with patch.object(hanamod, '_init', mock_hana):
+            with pytest.raises(exceptions.CommandExecutionError) as err:
+                hanamod.unset_ini_parameter(
+                    ini_parameter_names=[{'section_name': 'memorymanager',
+                                          'parameter_name':
+                                          'global_allocation_limit'}],
+                    database='db', file_name='global.ini', layer='SYSTEM',
+                    layer_name=None, reconfig=True, key_name='key',
+                    user_name='key_user', user_password='key_password',
+                    sid='prd', inst='00', password='pass')
+            mock_hana.assert_called_once_with('prd', '00', 'pass')
+            mock_hana_inst.unset_ini_parameter.assert_called_once_with(
+                ini_parameter_names=[{'section_name': 'memorymanager',
+                                      'parameter_name': 'global_allocation_limit'}],
+                database='db', file_name='global.ini',
+                layer_name=None, layer='SYSTEM', reconfig=True,
+                key_name='key', user_name='key_user', user_password='key_password')
+            assert 'hana error' in str(err)


### PR DESCRIPTION
I created a new PR with fewer commit history and all the relevant code changes.
This includes:
1) wrapper module functions for shaptools:
-set_ini_parameter
-unset_ini_parameter

2) salt state 'memory_resources_reduced' for reducing HANA memory resources