### PR TITLE
Feature/db pas instances

### DIFF
--- a/salt/modules/hanamod.py
+++ b/salt/modules/hanamod.py
@@ -856,10 +856,10 @@ def wait_for_connection(
 
     .. code-block:: bash
 
-        salt '*' hana.wait_for_hana 192.168.10.15 30013 SYSTEM pass
+        salt '*' hana.wait_for_hana 192.168.10.15 30015 SYSTEM pass
     '''
     connector = hdb_connector.HdbConnector()
-    current_time = time.clock()
+    current_time = time.time()
     current_timeout = current_time + timeout
     while current_time <= current_timeout:
         try:
@@ -868,10 +868,8 @@ def wait_for_connection(
             break
 
         except base_connector.ConnectionError:
-            continue
-
-        time.sleep(interval)
-        current_time = time.clock()
+            time.sleep(interval)
+            current_time = time.time()
     else:
         raise exceptions.CommandExecutionError(
             'HANA database not available after {} seconds in {}:{}'.format(

--- a/salt/modules/netweavermod.py
+++ b/salt/modules/netweavermod.py
@@ -89,7 +89,7 @@ def is_installed(
         Netweaver instance password
     sap_instance
         Check for specific SAP instances. Available options: ascs, ers, pas, aas.
-        If None it will checked if any instance is installed
+        If None it will check if any instance is installed
 
     Returns:
         bool: True if installed, False otherwise
@@ -132,7 +132,7 @@ def is_db_installed(
     '''
     if 'hana.wait_for_connection' not in __salt__:
         raise exceptions.CommandExecutionError(
-            'hana.wait_for_connection not available. hanamod must be installed')
+            'hana.wait_for_connection not available. hanamod must be installed and loaded')
 
     try:
         __salt__['hana.wait_for_connection'](
@@ -206,6 +206,8 @@ def install(
         Root user password
     cwd
         New value for SAPINST_CWD parameter
+        CAUTION: All of the files stored in this path will be removed except the
+        start_dir.cd. This folder only will contain temporary files about the installation
 
     CLI Example:
 
@@ -248,6 +250,8 @@ def install_ers(
         Root user password
     cwd
         New value for SAPINST_CWD parameter
+        CAUTION: All of the files stored in this path will be removed except the
+        start_dir.cd. This folder only will contain temporary files about the installation
     ascs_password
         Password of the SAP user in the machine hosting the ASCS instance.
         If it's not set the same password used to install ERS will be used
@@ -272,7 +276,7 @@ def install_ers(
 
 def setup_cwd(
         software_path,
-        cwd='/tmp/unattended',
+        cwd='/tmp/swpm_unattended',
         additional_dvds=None):
     '''
     Setup folder to run the sapinst tool in other directory (modified SAPINST_CWD)
@@ -282,6 +286,8 @@ def setup_cwd(
     cwd
         Path used to run the installation. All the files created during the installation will
         be stored there.
+        CAUTION: All of the files stored in this path will be removed except the
+        start_dir.cd. This folder only will contain temporary files about the installation
     additional_dvds
         Path to additional folders used during the installation
     '''

--- a/salt/modules/netweavermod.py
+++ b/salt/modules/netweavermod.py
@@ -104,6 +104,49 @@ def is_installed(
     return netweaver_inst.is_installed(sap_instance)
 
 
+def is_db_installed(
+        host,
+        port,
+        schema_name,
+        schema_password):
+    '''
+    Check if SAP Netweaver DB instance is installed
+
+    host:
+        Host where HANA is running
+    port:
+        HANA database port
+    schema_name:
+        Schema installed in the dabase
+    schema_password:
+        Password of the user for the schema
+
+    Returns:
+        bool: True if installed, False otherwise
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' netweaver.is_db_installed 192.168.10.15 30013 SAPABAP1 password
+    '''
+    if 'hana.wait_for_connection' not in __salt__:
+        raise exceptions.CommandExecutionError(
+            'hana.wait_for_connection not available. hanamod must be installed')
+
+    try:
+        __salt__['hana.wait_for_connection'](
+            host=host,
+            port=port,
+            user=schema_name,
+            password=schema_password,
+            timeout=0,
+            interval=0)
+        return True
+    except exceptions.CommandExecutionError:
+        return False
+
+
 def attach_virtual_host(
         virtual_host,
         virtual_host_interface='eth0'):
@@ -245,12 +288,12 @@ def setup_cwd(
 
     # Create folder. Remove if already exists first
     __salt__['file.remove'](cwd)
-    __salt__['file.mkdir'](cwd, user='root', group='sapinst', mode=755)
+    __salt__['file.mkdir'](cwd, user='root', group='sapinst', mode=775)
     # Create start_dir.cd file
     start_dir = '{}/start_dir.cd'.format(cwd)
     __salt__['file.touch'](start_dir)
     __salt__['file.chown'](start_dir, 'root', 'sapinst')
-    __salt__['file.set_mode'](start_dir, 755)
+    __salt__['file.set_mode'](start_dir, 775)
     # Add sapints_folder
     __salt__['file.append'](start_dir, args=software_path)
     # Add additional dvds. Add just /swpm at the beginning

--- a/salt/modules/netweavermod.py
+++ b/salt/modules/netweavermod.py
@@ -244,14 +244,16 @@ def setup_cwd(
     '''
 
     # Create folder. Remove if already exists first
-    __salt__['file.directory'](cwd, user='sapinst', dir_mode=755, clean=True)
+    __salt__['file.remove'](cwd)
+    __salt__['file.mkdir'](cwd, user='root', group='sapinst', mode=755)
     # Create start_dir.cd file
     start_dir = '{}/start_dir.cd'.format(cwd)
-    __salt__['file.managed'](start_dir, user='sapinst', dir_mode=755)
+    __salt__['file.touch'](start_dir)
+    __salt__['file.chown'](start_dir, 'root', 'sapinst')
+    __salt__['file.set_mode'](start_dir, 755)
     # Add sapints_folder
-    __salt__['file.append'](start_dir, text=software_path)
+    __salt__['file.append'](start_dir, args=software_path)
     # Add additional dvds. Add just /swpm at the beginning
-    for dvd in additional_dvds:
-        __salt__['file.append'](start_dir, text='/swpm/{}'.format(dvd))
+    __salt__['file.append'](start_dir, args=['/swpm/{}'.format(dvd) for dvd in additional_dvds])
 
     return cwd

--- a/salt/states/hanamod.py
+++ b/salt/states/hanamod.py
@@ -89,6 +89,54 @@ def _parse_dict(dict_params):
     return output
 
 
+def available(
+        name,
+        port,
+        user,
+        password,
+        timeout=60,
+        interval=5):
+    '''
+    Wait until HANA is ready trying to connect to the database
+
+    host:
+        Host where HANA is running
+    port:
+        HANA database port
+    user:
+        User to connect to the databse
+    password:
+        Password to connect to the database
+    timeout:
+        Timeout to try to connect to the database
+    interval:
+        Interval to try the connection
+    '''
+    host = name
+
+    ret = {'name': '{}:{}'.format(host, port),
+           'changes': {},
+           'result': False,
+           'comment': ''}
+
+    try:
+        __salt__['hana.wait_for_connection'](
+            host=host,
+            port=port,
+            user=user,
+            password=password,
+            timeout=timeout,
+            interval=interval)
+    except exceptions.CommandExecutionError as err:
+        ret['comment'] = six.text_type(err)
+        return ret
+
+    ret['result'] = True
+    ret['comment'] = 'HANA is available'
+
+    return ret
+
+
 def installed(
         name,
         inst,

--- a/salt/states/hanamod.py
+++ b/salt/states/hanamod.py
@@ -119,6 +119,11 @@ def available(
            'result': False,
            'comment': ''}
 
+    if __opts__['test']:
+        ret['result'] = None
+        ret['comment'] = 'hana connection would be checked'
+        return ret
+
     try:
         __salt__['hana.wait_for_connection'](
             host=host,

--- a/salt/states/netweavermod.py
+++ b/salt/states/netweavermod.py
@@ -261,7 +261,7 @@ def db_installed(
 
     if __opts__['test']:
         ret['result'] = None
-        ret['comment'] = 'Netweaver DB insatnce would be installed'
+        ret['comment'] = 'Netweaver DB instance would be installed'
         ret['changes']['host'] = '{}:{}'.format(host, port)
         return ret
 

--- a/salt/states/netweavermod.py
+++ b/salt/states/netweavermod.py
@@ -29,9 +29,10 @@ State module to provide SAP Netweaver functionality to Salt
       - software_path: /swpm
       - root_user: root
       - root_password: linux
+      - config_file: /inifile.params
       - virtual_host: ha1virthost
+      - virtual_host_interface: eth1
       - product_id: NW_ABAP_ASCS:NW750.HDB.ABAPHA
-      - sap_instance=ascs
 '''
 
 # Import python libs
@@ -70,6 +71,8 @@ def installed(
         virtual_host,
         virtual_host_interface,
         product_id,
+        cwd='/tmp/unattended',
+        additional_dvds=None,
         ascs_password=None,
         timeout=0,
         interval=5):
@@ -97,6 +100,10 @@ def installed(
         Network interface to attach the virtual host ip address
     product_id
         Id of the product to be installed. Example: NW_ABAP_ASCS:NW750.HDB.ABAPHA
+    cwd
+        New value for SAPINST_CWD parameter
+    additional_dvds
+        Additional folder where to retrieve required software for the installation
     ascs_password (Only used when the Product is ERS.)
         Password of the SAP user in the machine hosting the ASCS instance.
         If it's not set the same password used to install ERS will be used
@@ -136,12 +143,19 @@ def installed(
             virtual_host=virtual_host,
             virtual_host_interface=virtual_host_interface)
 
+        if cwd:
+            cwd = __salt__['netweaver.setup_cwd'](
+                software_path=software_path,
+                cwd=cwd,
+                additional_dvds=additional_dvds)
+
         if sap_instance == 'ers':
             __salt__['netweaver.install_ers'](
                 software_path=software_path,
                 virtual_host=virtual_host,
                 product_id=product_id,
                 conf_file=config_file,
+                cwd=cwd,
                 root_user=root_user,
                 root_password=root_password,
                 ascs_password=ascs_password,
@@ -154,6 +168,7 @@ def installed(
                 virtual_host=virtual_host,
                 product_id=product_id,
                 conf_file=config_file,
+                cwd=cwd,
                 root_user=root_user,
                 root_password=root_password)
 

--- a/salt/states/netweavermod.py
+++ b/salt/states/netweavermod.py
@@ -149,6 +149,12 @@ def installed(
                 cwd=cwd,
                 additional_dvds=additional_dvds)
 
+        # This state is applied due an error raised during AAS installation saying the permissions
+        # to create files inside this folder are not valid
+        if sap_instance == 'di':
+            __salt__['file.chown'](
+                '/usr/sap/{}'.format(sid.upper()), '{}adm'.format(sid.lower()), 'sapsys')
+
         if sap_instance == 'ers':
             __salt__['netweaver.install_ers'](
                 software_path=software_path,

--- a/salt/states/netweavermod.py
+++ b/salt/states/netweavermod.py
@@ -71,7 +71,7 @@ def installed(
         virtual_host,
         virtual_host_interface,
         product_id,
-        cwd='/tmp/unattended',
+        cwd='/tmp/swpm_unattended',
         additional_dvds=None,
         ascs_password=None,
         timeout=0,
@@ -102,6 +102,8 @@ def installed(
         Id of the product to be installed. Example: NW_ABAP_ASCS:NW750.HDB.ABAPHA
     cwd
         New value for SAPINST_CWD parameter
+        CAUTION: All of the files stored in this path will be removed except the
+        start_dir.cd. This folder only will contain temporary files about the installation
     additional_dvds
         Additional folder where to retrieve required software for the installation
     ascs_password (Only used when the Product is ERS.)
@@ -210,7 +212,7 @@ def db_installed(
         virtual_host,
         virtual_host_interface,
         product_id,
-        cwd='/tmp/unattended',
+        cwd='/tmp/swpm_unattended',
         additional_dvds=None):
     """
     Install SAP Netweaver DB instance if the instance is not installed yet.

--- a/tests/unit/modules/test_netweavermod.py
+++ b/tests/unit/modules/test_netweavermod.py
@@ -180,9 +180,9 @@ class NetweaverModuleTest(TestCase, LoaderModuleMockMixin):
         Test install method - return
         '''
         netweavermod.install(
-            'software_path', 'vhost', 'productID', 'netweaver.conf', 'root', 'root')
+            'software_path', 'vhost', 'productID', 'netweaver.conf', 'root', 'root', cwd='/tmp')
         mock_netweaver.install.assert_called_once_with(
-            'software_path', 'vhost', 'productID', 'netweaver.conf', 'root', 'root')
+            'software_path', 'vhost', 'productID', 'netweaver.conf', 'root', 'root', cwd='/tmp')
 
     @patch('salt.modules.netweavermod.netweaver.NetweaverInstance')
     def test_install_raise(self, mock_netweaver):
@@ -195,7 +195,7 @@ class NetweaverModuleTest(TestCase, LoaderModuleMockMixin):
         with pytest.raises(exceptions.CommandExecutionError) as err:
             netweavermod.install('software_path', 'vhost', 'productID', 'netweaver.conf', 'root', 'root')
         mock_netweaver.install.assert_called_once_with(
-            'software_path', 'vhost', 'productID', 'netweaver.conf', 'root', 'root')
+            'software_path', 'vhost', 'productID', 'netweaver.conf', 'root', 'root', cwd=None)
         assert 'netweaver error' in str(err.value)
 
     @patch('salt.modules.netweavermod.netweaver.NetweaverInstance')
@@ -205,10 +205,10 @@ class NetweaverModuleTest(TestCase, LoaderModuleMockMixin):
         '''
         netweavermod.install_ers(
             'software_path', 'vhost', 'productID', 'netweaver.conf', 'root', 'root',
-            ascs_password='ascs', timeout=15, interval=2)
+            cwd='/tmp', ascs_password='ascs', timeout=15, interval=2)
         mock_netweaver.install_ers.assert_called_once_with(
             'software_path', 'vhost', 'productID', 'netweaver.conf',
-            'root', 'root', ascs_password='ascs', timeout=15, interval=2)
+            'root', 'root', cwd='/tmp', ascs_password='ascs', timeout=15, interval=2)
 
     @patch('salt.modules.netweavermod.netweaver.NetweaverInstance')
     def test_install_ers_raise(self, mock_netweaver):
@@ -222,5 +222,5 @@ class NetweaverModuleTest(TestCase, LoaderModuleMockMixin):
             netweavermod.install_ers('software_path', 'vhost', 'productID', 'netweaver.conf', 'root', 'root')
         mock_netweaver.install_ers.assert_called_once_with(
             'software_path', 'vhost', 'productID', 'netweaver.conf',
-            'root', 'root', ascs_password=None, timeout=0, interval=5)
+            'root', 'root', ascs_password=None, timeout=0, interval=5, cwd=None)
         assert 'netweaver error' in str(err.value)

--- a/tests/unit/states/test_netweavermod.py
+++ b/tests/unit/states/test_netweavermod.py
@@ -86,7 +86,7 @@ class NetweavermodTestCase(TestCase, LoaderModuleMockMixin):
     @mock.patch('salt.states.netweavermod._get_sap_instance_type')
     def test_installed_command_error(self, mock_get):
         '''
-        Test to check installed in test mode
+        Test to check installed when it raises an error
         '''
 
         ret = {'name': 'prd',
@@ -111,29 +111,31 @@ class NetweavermodTestCase(TestCase, LoaderModuleMockMixin):
     @mock.patch('salt.states.netweavermod._get_sap_instance_type')
     def test_installed_correct(self, mock_get):
         '''
-        Test to check installed in test mode
+        Test to check installed when it is installed correctly
         '''
 
         ret = {'name': 'prd',
                'changes': {'sid': 'prd'},
                'result': True,
-               'comment': 'Netweaver ascs installed'}
+               'comment': 'Netweaver di installed'}
 
         mock_installed = MagicMock(side_effect=[False, True])
-        mock_get.return_value = 'ascs'
+        mock_get.return_value = 'di'
         mock_attach = MagicMock(return_value='192.168.15.1')
         mock_setup_cwd = MagicMock(return_value='/tmp_nw')
         mock_install = MagicMock()
+        mock_chown = MagicMock()
         with patch.dict(netweavermod.__salt__, {'netweaver.is_installed': mock_installed,
                                                 'netweaver.attach_virtual_host': mock_attach,
                                                 'netweaver.setup_cwd': mock_setup_cwd,
-                                                'netweaver.install': mock_install}):
+                                                'netweaver.install': mock_install,
+                                                'file.chown': mock_chown}):
             assert netweavermod.installed(
                 'prd', '00', 'pass', '/software', 'root', 'pass',
                 'config_file', 'vhost', 'eth1', 'productID', cwd='/tmp') == ret
             mock_installed.assert_has_calls([
-                mock.call(sid='prd', inst='00', password='pass', sap_instance='ascs'),
-                mock.call(sid='prd', inst='00', password='pass', sap_instance='ascs'),
+                mock.call(sid='prd', inst='00', password='pass', sap_instance='di'),
+                mock.call(sid='prd', inst='00', password='pass', sap_instance='di'),
             ])
 
             mock_get.assert_called_once_with('productID')
@@ -149,7 +151,7 @@ class NetweavermodTestCase(TestCase, LoaderModuleMockMixin):
     @mock.patch('salt.states.netweavermod._get_sap_instance_type')
     def test_installed_ers_correct(self, mock_get):
         '''
-        Test to check installed in test mode
+        Test to check installed when ers is installed correctly
         '''
 
         ret = {'name': 'prd',
@@ -162,10 +164,12 @@ class NetweavermodTestCase(TestCase, LoaderModuleMockMixin):
         mock_attach = MagicMock(return_value='192.168.15.1')
         mock_setup_cwd = MagicMock(return_value='/tmp_nw')
         mock_install = MagicMock()
+        mock_chown = MagicMock()
         with patch.dict(netweavermod.__salt__, {'netweaver.is_installed': mock_installed,
                                                 'netweaver.attach_virtual_host': mock_attach,
                                                 'netweaver.setup_cwd': mock_setup_cwd,
-                                                'netweaver.install_ers': mock_install}):
+                                                'netweaver.install_ers': mock_install,
+                                                'file.chown': mock_chown}):
             assert netweavermod.installed(
                 'prd', '00', 'pass', '/software', 'root', 'pass',
                 'config_file', 'vhost', 'eth1', 'productID', ascs_password='ascs_pass') == ret
@@ -174,6 +178,7 @@ class NetweavermodTestCase(TestCase, LoaderModuleMockMixin):
                 mock.call(sid='prd', inst='00', password='pass', sap_instance='ers'),
             ])
 
+            assert mock_chown.call_count == 0
             mock_get.assert_called_once_with('productID')
             mock_attach.assert_called_once_with(
                 virtual_host='vhost', virtual_host_interface='eth1')
@@ -188,7 +193,7 @@ class NetweavermodTestCase(TestCase, LoaderModuleMockMixin):
     @mock.patch('salt.states.netweavermod._get_sap_instance_type')
     def test_installed_not_installed(self, mock_get):
         '''
-        Test to check installed in test mode
+        Test to check installed when the installation fails
         '''
 
         ret = {'name': 'prd',
@@ -214,6 +219,150 @@ class NetweavermodTestCase(TestCase, LoaderModuleMockMixin):
             ])
 
             mock_get.assert_called_once_with('productID')
+            mock_attach.assert_called_once_with(
+                virtual_host='vhost', virtual_host_interface='eth1')
+            mock_setup_cwd.assert_called_once_with(
+                software_path='/software', cwd='/tmp/unattended', additional_dvds=None)
+            mock_install.assert_called_once_with(
+                software_path='/software', virtual_host='vhost',
+                product_id='productID', conf_file='config_file',
+                root_user='root', root_password='pass', cwd='/tmp_nw')
+
+    # 'db_installed' function tests
+
+    def test_db_installed_installed(self):
+        '''
+        Test to check db installed when netweaver is already installed
+        '''
+
+        ret = {'name': '192.168.10.15:30015',
+               'changes': {},
+               'result': True,
+               'comment': 'Netweaver DB instance is already installed'}
+
+        mock_db_installed = MagicMock(return_value=True)
+        with patch.dict(netweavermod.__salt__, {'netweaver.is_db_installed': mock_db_installed}):
+            assert netweavermod.db_installed(
+                '192.168.10.15', 30015, 'SAPABAP1', 'schema_pass',
+                '/software', 'root', 'pass',
+                'config_file', 'vhost', 'eth1', 'productID') == ret
+            mock_db_installed.assert_called_once_with(
+                host='192.168.10.15', port=30015, schema_name='SAPABAP1', schema_password='schema_pass')
+
+    def test_db_installed_test(self):
+        '''
+        Test to check db_installed in test mode
+        '''
+
+        ret = {'name': '192.168.10.15:30015',
+               'changes': {'host': '192.168.10.15:30015'},
+               'result': None,
+               'comment': 'Netweaver DB instance would be installed'}
+
+        mock_db_installed = MagicMock(return_value=False)
+        with patch.dict(netweavermod.__salt__, {'netweaver.is_db_installed': mock_db_installed}):
+            with patch.dict(netweavermod.__opts__, {'test': True}):
+                assert netweavermod.db_installed(
+                    '192.168.10.15', 30015, 'SAPABAP1', 'schema_pass',
+                    '/software', 'root', 'pass',
+                    'config_file', 'vhost', 'eth1', 'productID') == ret
+            mock_db_installed.assert_called_once_with(
+                host='192.168.10.15', port=30015, schema_name='SAPABAP1', schema_password='schema_pass')
+
+    def test_db_installed_command_error(self):
+        '''
+        Test to check db_installed when it raises an error
+        '''
+
+        ret = {'name': '192.168.10.15:30015',
+               'changes': {},
+               'result': False,
+               'comment': 'error'}
+
+        mock_db_installed = MagicMock(return_value=False)
+        mock_attach = MagicMock(side_effect=exceptions.CommandExecutionError('error'))
+        with patch.dict(netweavermod.__salt__, {'netweaver.is_db_installed': mock_db_installed,
+                                                'netweaver.attach_virtual_host': mock_attach}):
+            assert netweavermod.db_installed(
+                '192.168.10.15', 30015, 'SAPABAP1', 'schema_pass',
+                '/software', 'root', 'pass',
+                'config_file', 'vhost', 'eth1', 'productID') == ret
+            mock_db_installed.assert_called_once_with(
+                host='192.168.10.15', port=30015, schema_name='SAPABAP1', schema_password='schema_pass')
+            mock_attach.assert_called_once_with(
+                virtual_host='vhost', virtual_host_interface='eth1')
+
+    def test_db_installed_correct(self):
+        '''
+        Test to check installed when it is installed correctly
+        '''
+
+        ret = {'name': '192.168.10.15:30015',
+               'changes': {'host': '192.168.10.15:30015'},
+               'result': True,
+               'comment': 'Netweaver DB instance installed'}
+
+        mock_db_installed = MagicMock(side_effect=[False, True])
+        mock_attach = MagicMock(return_value='192.168.15.1')
+        mock_setup_cwd = MagicMock(return_value='/tmp_nw')
+        mock_install = MagicMock()
+        with patch.dict(netweavermod.__salt__, {'netweaver.is_db_installed': mock_db_installed,
+                                                'netweaver.attach_virtual_host': mock_attach,
+                                                'netweaver.setup_cwd': mock_setup_cwd,
+                                                'netweaver.install': mock_install}):
+            assert netweavermod.db_installed(
+                '192.168.10.15', 30015, 'SAPABAP1', 'schema_pass',
+                '/software', 'root', 'pass',
+                'config_file', 'vhost', 'eth1', 'productID') == ret
+            mock_db_installed.assert_has_calls([
+                mock.call(
+                    host='192.168.10.15', port=30015,
+                    schema_name='SAPABAP1', schema_password='schema_pass'),
+                mock.call(
+                    host='192.168.10.15', port=30015,
+                    schema_name='SAPABAP1', schema_password='schema_pass'),
+            ])
+
+            mock_attach.assert_called_once_with(
+                virtual_host='vhost', virtual_host_interface='eth1')
+            mock_setup_cwd.assert_called_once_with(
+                software_path='/software', cwd='/tmp/unattended', additional_dvds=None)
+            mock_install.assert_called_once_with(
+                software_path='/software', virtual_host='vhost',
+                product_id='productID', conf_file='config_file',
+                root_user='root', root_password='pass', cwd='/tmp_nw')
+
+    def test_db_installed_not_installed(self):
+        '''
+        Test to check installed when the installation fails
+        '''
+
+        ret = {'name': '192.168.10.15:30015',
+               'changes': {},
+               'result': False,
+               'comment': 'Netweaver DB instance was not installed'}
+
+        mock_db_installed = MagicMock(side_effect=[False, False])
+        mock_attach = MagicMock(return_value='192.168.15.1')
+        mock_setup_cwd = MagicMock(return_value='/tmp_nw')
+        mock_install = MagicMock()
+        with patch.dict(netweavermod.__salt__, {'netweaver.is_db_installed': mock_db_installed,
+                                                'netweaver.attach_virtual_host': mock_attach,
+                                                'netweaver.setup_cwd': mock_setup_cwd,
+                                                'netweaver.install': mock_install}):
+            assert netweavermod.db_installed(
+                '192.168.10.15', 30015, 'SAPABAP1', 'schema_pass',
+                '/software', 'root', 'pass',
+                'config_file', 'vhost', 'eth1', 'productID') == ret
+            mock_db_installed.assert_has_calls([
+                mock.call(
+                    host='192.168.10.15', port=30015,
+                    schema_name='SAPABAP1', schema_password='schema_pass'),
+                mock.call(
+                    host='192.168.10.15', port=30015,
+                    schema_name='SAPABAP1', schema_password='schema_pass'),
+            ])
+
             mock_attach.assert_called_once_with(
                 virtual_host='vhost', virtual_host_interface='eth1')
             mock_setup_cwd.assert_called_once_with(

--- a/tests/unit/states/test_netweavermod.py
+++ b/tests/unit/states/test_netweavermod.py
@@ -122,13 +122,15 @@ class NetweavermodTestCase(TestCase, LoaderModuleMockMixin):
         mock_installed = MagicMock(side_effect=[False, True])
         mock_get.return_value = 'ascs'
         mock_attach = MagicMock(return_value='192.168.15.1')
+        mock_setup_cwd = MagicMock(return_value='/tmp_nw')
         mock_install = MagicMock()
         with patch.dict(netweavermod.__salt__, {'netweaver.is_installed': mock_installed,
                                                 'netweaver.attach_virtual_host': mock_attach,
+                                                'netweaver.setup_cwd': mock_setup_cwd,
                                                 'netweaver.install': mock_install}):
             assert netweavermod.installed(
                 'prd', '00', 'pass', '/software', 'root', 'pass',
-                'config_file', 'vhost', 'eth1', 'productID') == ret
+                'config_file', 'vhost', 'eth1', 'productID', cwd='/tmp') == ret
             mock_installed.assert_has_calls([
                 mock.call(sid='prd', inst='00', password='pass', sap_instance='ascs'),
                 mock.call(sid='prd', inst='00', password='pass', sap_instance='ascs'),
@@ -137,10 +139,12 @@ class NetweavermodTestCase(TestCase, LoaderModuleMockMixin):
             mock_get.assert_called_once_with('productID')
             mock_attach.assert_called_once_with(
                 virtual_host='vhost', virtual_host_interface='eth1')
+            mock_setup_cwd.assert_called_once_with(
+                software_path='/software', cwd='/tmp', additional_dvds=None)
             mock_install.assert_called_once_with(
                 software_path='/software', virtual_host='vhost',
                 product_id='productID', conf_file='config_file',
-                root_user='root', root_password='pass')
+                root_user='root', root_password='pass', cwd='/tmp_nw')
 
     @mock.patch('salt.states.netweavermod._get_sap_instance_type')
     def test_installed_ers_correct(self, mock_get):
@@ -156,9 +160,11 @@ class NetweavermodTestCase(TestCase, LoaderModuleMockMixin):
         mock_installed = MagicMock(side_effect=[False, True])
         mock_get.return_value = 'ers'
         mock_attach = MagicMock(return_value='192.168.15.1')
+        mock_setup_cwd = MagicMock(return_value='/tmp_nw')
         mock_install = MagicMock()
         with patch.dict(netweavermod.__salt__, {'netweaver.is_installed': mock_installed,
                                                 'netweaver.attach_virtual_host': mock_attach,
+                                                'netweaver.setup_cwd': mock_setup_cwd,
                                                 'netweaver.install_ers': mock_install}):
             assert netweavermod.installed(
                 'prd', '00', 'pass', '/software', 'root', 'pass',
@@ -171,10 +177,13 @@ class NetweavermodTestCase(TestCase, LoaderModuleMockMixin):
             mock_get.assert_called_once_with('productID')
             mock_attach.assert_called_once_with(
                 virtual_host='vhost', virtual_host_interface='eth1')
+            mock_setup_cwd.assert_called_once_with(
+                software_path='/software', cwd='/tmp/unattended', additional_dvds=None)
             mock_install.assert_called_once_with(
                 software_path='/software', virtual_host='vhost',
                 product_id='productID', conf_file='config_file',
-                root_user='root', root_password='pass', ascs_password='ascs_pass', timeout=0, interval=5)
+                root_user='root', root_password='pass',
+                cwd='/tmp_nw', ascs_password='ascs_pass', timeout=0, interval=5)
 
     @mock.patch('salt.states.netweavermod._get_sap_instance_type')
     def test_installed_not_installed(self, mock_get):
@@ -190,9 +199,11 @@ class NetweavermodTestCase(TestCase, LoaderModuleMockMixin):
         mock_installed = MagicMock(side_effect=[False, False])
         mock_get.return_value = ''
         mock_attach = MagicMock(return_value='192.168.15.1')
+        mock_setup_cwd = MagicMock(return_value='/tmp_nw')
         mock_install = MagicMock()
         with patch.dict(netweavermod.__salt__, {'netweaver.is_installed': mock_installed,
                                                 'netweaver.attach_virtual_host': mock_attach,
+                                                'netweaver.setup_cwd': mock_setup_cwd,
                                                 'netweaver.install': mock_install}):
             assert netweavermod.installed(
                 'prd', '00', 'pass', '/software', 'root', 'pass',
@@ -205,7 +216,9 @@ class NetweavermodTestCase(TestCase, LoaderModuleMockMixin):
             mock_get.assert_called_once_with('productID')
             mock_attach.assert_called_once_with(
                 virtual_host='vhost', virtual_host_interface='eth1')
+            mock_setup_cwd.assert_called_once_with(
+                software_path='/software', cwd='/tmp/unattended', additional_dvds=None)
             mock_install.assert_called_once_with(
                 software_path='/software', virtual_host='vhost',
                 product_id='productID', conf_file='config_file',
-                root_user='root', root_password='pass')
+                root_user='root', root_password='pass', cwd='/tmp_nw')

--- a/tests/unit/states/test_netweavermod.py
+++ b/tests/unit/states/test_netweavermod.py
@@ -183,7 +183,7 @@ class NetweavermodTestCase(TestCase, LoaderModuleMockMixin):
             mock_attach.assert_called_once_with(
                 virtual_host='vhost', virtual_host_interface='eth1')
             mock_setup_cwd.assert_called_once_with(
-                software_path='/software', cwd='/tmp/unattended', additional_dvds=None)
+                software_path='/software', cwd='/tmp/swpm_unattended', additional_dvds=None)
             mock_install.assert_called_once_with(
                 software_path='/software', virtual_host='vhost',
                 product_id='productID', conf_file='config_file',
@@ -222,7 +222,7 @@ class NetweavermodTestCase(TestCase, LoaderModuleMockMixin):
             mock_attach.assert_called_once_with(
                 virtual_host='vhost', virtual_host_interface='eth1')
             mock_setup_cwd.assert_called_once_with(
-                software_path='/software', cwd='/tmp/unattended', additional_dvds=None)
+                software_path='/software', cwd='/tmp/swpm_unattended', additional_dvds=None)
             mock_install.assert_called_once_with(
                 software_path='/software', virtual_host='vhost',
                 product_id='productID', conf_file='config_file',
@@ -326,7 +326,7 @@ class NetweavermodTestCase(TestCase, LoaderModuleMockMixin):
             mock_attach.assert_called_once_with(
                 virtual_host='vhost', virtual_host_interface='eth1')
             mock_setup_cwd.assert_called_once_with(
-                software_path='/software', cwd='/tmp/unattended', additional_dvds=None)
+                software_path='/software', cwd='/tmp/swpm_unattended', additional_dvds=None)
             mock_install.assert_called_once_with(
                 software_path='/software', virtual_host='vhost',
                 product_id='productID', conf_file='config_file',
@@ -366,7 +366,7 @@ class NetweavermodTestCase(TestCase, LoaderModuleMockMixin):
             mock_attach.assert_called_once_with(
                 virtual_host='vhost', virtual_host_interface='eth1')
             mock_setup_cwd.assert_called_once_with(
-                software_path='/software', cwd='/tmp/unattended', additional_dvds=None)
+                software_path='/software', cwd='/tmp/swpm_unattended', additional_dvds=None)
             mock_install.assert_called_once_with(
                 software_path='/software', virtual_host='vhost',
                 product_id='productID', conf_file='config_file',


### PR DESCRIPTION
Add new salt modules and states to manage DB, PAS and AAS Netweaver installations.

To use them, we need to check if a Hana database is available (`wait_for_connection`).
The db installation uses this way to check if the Netweaver DB import is done or not