### PR TITLE
Fix Issue39 DRBD error parsing status

### DIFF
--- a/salt-shaptools.changes
+++ b/salt-shaptools.changes
@@ -1,4 +1,9 @@
 -------------------------------------------------------------------
+Thu Nov 21 09:05:07 UTC 2019 - nick wang <nwang@suse.com>
+
+- Version 0.2.4, fix error parsing drbd status when congested.
+
+-------------------------------------------------------------------
 Mon Nov  5 08:48:50 UTC 2019 - nick wang <nwang@suse.com>
 
 - Create package version 0.2.3 with drbd files renamed.

--- a/salt-shaptools.spec
+++ b/salt-shaptools.spec
@@ -19,7 +19,7 @@
 # See also https://en.opensuse.org/openSUSE:Specfile_guidelines
 
 Name:           salt-shaptools
-Version:        0.2.3
+Version:        0.2.4
 Release:        0
 Summary:        Salt modules and states for SAP Applications and SLE-HA components management
 

--- a/salt/modules/drbdmod.py
+++ b/salt/modules/drbdmod.py
@@ -30,6 +30,8 @@ LOGGER = logging.getLogger(__name__)
 __virtualname__ = 'drbd'
 
 DRBD_COMMAND = 'drbdadm'
+ERR_STR = 'UNKNOWN'
+DUMMY_STR = 'IGNORED'
 
 
 def __virtual__():  # pragma: no cover
@@ -86,11 +88,11 @@ def _analyse_status_type(line):
         0: 'RESOURCE',
         2: {' disk:': 'LOCALDISK', ' role:': 'PEERNODE', ' connection:': 'PEERNODE'},
         4: {' peer-disk:': 'PEERDISK'},
-        6: 'IGNORED',
-        8: 'IGNORED',
+        6: DUMMY_STR,
+        8: DUMMY_STR,
     }
 
-    ret = switch.get(spaces, 'UNKNOWN')
+    ret = switch.get(spaces, ERR_STR)
 
     # isinstance(ret, str) only works when run directly, calling need unicode(six)
     if isinstance(ret, six.text_type):
@@ -101,7 +103,7 @@ def _analyse_status_type(line):
             return ret[x]
 
     # Doesn't find expected KEY in support indent
-    return 'UNKNOWN'
+    return ERR_STR
 
 
 def _add_res(line):
@@ -196,12 +198,12 @@ def _line_parser(line):
 
     switch = {
         '': _empty,
-        'IGNORED': _empty,
         'RESOURCE': _add_res,
         'PEERNODE': _add_peernode,
         'LOCALDISK': _add_volume,
         'PEERDISK': _add_volume,
-        'UNKNOWN': _unknown_parser,
+        DUMMY_STR: _empty,
+        ERR_STR: _unknown_parser,
     }
 
     func = switch.get(section, _unknown_parser)

--- a/salt/modules/drbdmod.py
+++ b/salt/modules/drbdmod.py
@@ -85,7 +85,9 @@ def _analyse_status_type(line):
     switch = {
         0: 'RESOURCE',
         2: {' disk:': 'LOCALDISK', ' role:': 'PEERNODE', ' connection:': 'PEERNODE'},
-        4: {' peer-disk:': 'PEERDISK'}
+        4: {' peer-disk:': 'PEERDISK'},
+        6: 'IGNORED',
+        8: 'IGNORED',
     }
 
     ret = switch.get(spaces, 'UNKNOWN')
@@ -97,6 +99,9 @@ def _analyse_status_type(line):
     for x in ret:
         if x in line:
             return ret[x]
+
+    # Doesn't find expected KEY in support indent
+    return 'UNKNOWN'
 
 
 def _add_res(line):
@@ -171,7 +176,7 @@ def _add_peernode(line):
 
 def _empty(dummy):
     '''
-    Action of empty line of ``drbdadm status``
+    Action of empty line or extra verbose info of ``drbdadm status``
     '''
 
 
@@ -191,6 +196,7 @@ def _line_parser(line):
 
     switch = {
         '': _empty,
+        'IGNORED': _empty,
         'RESOURCE': _add_res,
         'PEERNODE': _add_peernode,
         'LOCALDISK': _add_volume,

--- a/tests/unit/modules/test_drbdmod.py
+++ b/tests/unit/modules/test_drbdmod.py
@@ -186,7 +186,7 @@ res role:Primary
         with patch.dict(drbd.__salt__, {'cmd.run_all': mock_cmd}):
             assert drbd.status() == ret
 
-        ret = {'Unknown parser': ' single role:Primary'}
+        # SubTest: Test the _unknown_parser
         fake = {}
         fake['stdout'] = '''
  single role:Primary
@@ -197,7 +197,23 @@ res role:Primary
         mock_cmd = MagicMock(return_value=fake)
 
         with patch.dict(drbd.__salt__, {'cmd.run_all': mock_cmd}):
-            assert drbd.status() == ret
+            self.assertRaises(exceptions.CommandExecutionError, drbd.status)
+
+        # SubTest: Test the right indent but no expected KEY
+        fake = {}
+        fake['stdout'] = '''
+single role:Primary
+  error-key:UpToDate
+  opensuse-node2 role:Secondary
+    replication:SyncSource peer-disk:Inconsistent done:96.47
+'''
+        fake['stderr'] = ""
+        fake['retcode'] = 0
+
+        mock_cmd = MagicMock(return_value=fake)
+
+        with patch.dict(drbd.__salt__, {'cmd.run_all': mock_cmd}):
+            self.assertRaises(exceptions.CommandExecutionError, drbd.status)
 
     def test_createmd(self):
         '''


### PR DESCRIPTION
Issue: https://github.com/SUSE/salt-shaptools/issues/39
    
The `drbdadm status` output may to new line with small resolution.
Especeially when syncing congested.
Ignore the indent 6 and 8 in this case.
    
Eventually will replace the whole method with `json` output.
