### PR TITLE
DRBD: check unfinished request of sync status

### DIFF
--- a/salt-shaptools.changes
+++ b/salt-shaptools.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Fri Dec 20 09:12:51 UTC 2019 - nick wang <nwang@suse.com>
+
+- Version 0.2.8
+  * DRBD: check unfinished request in sync status via json
+
+-------------------------------------------------------------------
 Mon Dec 16 09:31:18 UTC 2019 - Xabier Arbulu <xarbulu@suse.com>
 
 - Version 0.2.7

--- a/salt-shaptools.spec
+++ b/salt-shaptools.spec
@@ -19,7 +19,7 @@
 # See also https://en.opensuse.org/openSUSE:Specfile_guidelines
 
 Name:           salt-shaptools
-Version:        0.2.7
+Version:        0.2.8
 Release:        0
 Summary:        Salt modules and states for SAP Applications and SLE-HA components management
 

--- a/tests/unit/modules/test_drbdmod.py
+++ b/tests/unit/modules/test_drbdmod.py
@@ -719,3 +719,200 @@ beijing role:Primary
         with patch.dict(drbd.__salt__, {'cmd.run_all': mock_cmd}):
             assert drbd.check_sync_status('shanghai')
             mock_cmd.assert_called_with('drbdsetup status --json shanghai')
+
+        # Test 2: Test _is_no_backing_dev_request() return no "res"
+        fake = {}
+        fake['stdout'] = '''
+[
+{
+  "name": "shanghai",
+  "node-id": 1,
+  "role": "Secondary",
+  "suspended": false,
+  "write-ordering": "flush",
+  "devices": [
+    {
+      "volume": 0,
+      "minor": 2,
+      "disk-state": "UpToDate",
+      "client": false,
+      "quorum": true,
+      "size": 699332,
+      "read": 0,
+      "written": 0,
+      "al-writes": 0,
+      "bm-writes": 0,
+      "upper-pending": 0,
+      "lower-pending": 0
+    } ],
+  "connections": [
+    {
+      "peer-node-id": 2,
+      "name": "dummytest-drbd02",
+      "connection-state": "Connected",
+      "congested": false,
+      "peer-role": "Secondary",
+      "ap-in-flight": 0,
+      "rs-in-flight": 0,
+      "peer_devices": [
+        {
+          "volume": 0,
+          "replication-state": "Established",
+          "peer-disk-state": "UpToDate",
+          "peer-client": false,
+          "resync-suspended": "no",
+          "received": 0,
+          "sent": 0,
+          "out-of-sync": 0,
+          "pending": 0,
+          "unacked": 0,
+          "has-sync-details": false,
+          "has-online-verify-details": false,
+          "percent-in-sync": 100.00
+        } ]
+    } ]
+}
+]
+
+'''
+        fake['stderr'] = ""
+        fake['retcode'] = 0
+
+        fake1 = {}
+        fake1['stdout'] = ""
+        fake1['stderr'] = ""
+        fake1['retcode'] = 1
+
+        mock_cmd = MagicMock(side_effect=[fake, fake, fake1])
+
+        with patch.dict(drbd.__salt__, {'cmd.run_all': mock_cmd}):
+            assert not drbd.check_sync_status('shanghai')
+            mock_cmd.assert_called_with('drbdsetup status --json shanghai')
+
+        # Test 3: Test _is_no_backing_dev_request() have unfinished requrests
+        fake = {}
+        fake['stdout'] = '''
+[
+{
+  "name": "shanghai",
+  "node-id": 1,
+  "role": "Secondary",
+  "suspended": false,
+  "write-ordering": "flush",
+  "devices": [
+    {
+      "volume": 0,
+      "minor": 2,
+      "disk-state": "UpToDate",
+      "client": false,
+      "quorum": true,
+      "size": 699332,
+      "read": 0,
+      "written": 0,
+      "al-writes": 0,
+      "bm-writes": 0,
+      "upper-pending": 0,
+      "lower-pending": 3
+    } ],
+  "connections": [
+    {
+      "peer-node-id": 2,
+      "name": "dummytest-drbd02",
+      "connection-state": "Connected",
+      "congested": false,
+      "peer-role": "Secondary",
+      "ap-in-flight": 0,
+      "rs-in-flight": 0,
+      "peer_devices": [
+        {
+          "volume": 0,
+          "replication-state": "Established",
+          "peer-disk-state": "UpToDate",
+          "peer-client": false,
+          "resync-suspended": "no",
+          "received": 0,
+          "sent": 0,
+          "out-of-sync": 0,
+          "pending": 0,
+          "unacked": 0,
+          "has-sync-details": false,
+          "has-online-verify-details": false,
+          "percent-in-sync": 100.00
+        } ]
+    } ]
+}
+]
+
+'''
+        fake['stderr'] = ""
+        fake['retcode'] = 0
+
+        mock_cmd = MagicMock(return_value=fake)
+
+        with patch.dict(drbd.__salt__, {'cmd.run_all': mock_cmd}):
+            assert not drbd.check_sync_status('shanghai')
+            mock_cmd.assert_called_with('drbdsetup status --json shanghai')
+
+        # Test 4: Test _is_no_backing_dev_request() all requrests finished
+        fake = {}
+        fake['stdout'] = '''
+[
+{
+  "name": "shanghai",
+  "node-id": 1,
+  "role": "Secondary",
+  "suspended": false,
+  "write-ordering": "flush",
+  "devices": [
+    {
+      "volume": 0,
+      "minor": 2,
+      "disk-state": "UpToDate",
+      "client": false,
+      "quorum": true,
+      "size": 699332,
+      "read": 0,
+      "written": 0,
+      "al-writes": 0,
+      "bm-writes": 0,
+      "upper-pending": 0,
+      "lower-pending": 0
+    } ],
+  "connections": [
+    {
+      "peer-node-id": 2,
+      "name": "dummytest-drbd02",
+      "connection-state": "Connected",
+      "congested": false,
+      "peer-role": "Secondary",
+      "ap-in-flight": 0,
+      "rs-in-flight": 0,
+      "peer_devices": [
+        {
+          "volume": 0,
+          "replication-state": "Established",
+          "peer-disk-state": "UpToDate",
+          "peer-client": false,
+          "resync-suspended": "no",
+          "received": 0,
+          "sent": 0,
+          "out-of-sync": 0,
+          "pending": 0,
+          "unacked": 0,
+          "has-sync-details": false,
+          "has-online-verify-details": false,
+          "percent-in-sync": 100.00
+        } ]
+    } ]
+}
+]
+
+'''
+        fake['stderr'] = ""
+        fake['retcode'] = 0
+
+        mock_cmd = MagicMock(return_value=fake)
+
+        with patch.dict(drbd.__salt__, {'cmd.run_all': mock_cmd}):
+            assert drbd.check_sync_status('shanghai')
+            mock_cmd.assert_called_with('drbdsetup status --json shanghai')


### PR DESCRIPTION
The sync target change status to UpToDate first
before syncing md. It may take unexpected long time
on lower level devices.
Checking the unfinished request even state is UpToDate.

Be aware still have possibility to make inconsistent
state of sync target and sync source. But this will
distinct drop the reason cause by slow backing device.