### PR TITLE
Feature/corosync configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ jobs:
           - git clone --depth=50 https://github.com/openSUSE/salt ../salt
           - rm ../salt/tests/conftest.py
           - git clone --depth=50 https://github.com/SUSE/shaptools.git ../shaptools
-          - pip install ../salt
+          - pip install -e ../salt
           - pip install ../shaptools
       script:
           - ./tests/run.sh
@@ -34,7 +34,7 @@ jobs:
           - git clone --depth=50 https://github.com/openSUSE/salt ../salt
           - rm ../salt/tests/conftest.py
           - git clone --depth=50 https://github.com/SUSE/shaptools.git ../shaptools
-          - pip install ../salt
+          - pip install -e ../salt
           - pip install ../shaptools
       before_script:
           - curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter

--- a/salt-shaptools.changes
+++ b/salt-shaptools.changes
@@ -1,4 +1,12 @@
 -------------------------------------------------------------------
+Thu Mar  5 10:03:39 UTC 2020 - Xabier Arbulu <xarbulu@suse.com>
+
+- Version 0.3.2
+  * Add a new salt state method to update corosync configuration
+    file
+  * Fix travis file to install the py packages in develop mode 
+
+-------------------------------------------------------------------
 Fri Jan 24 10:40:26 UTC 2020 - Xabier Arbulu <xarbulu@suse.com>
 
 - Version 0.3.1

--- a/salt-shaptools.spec
+++ b/salt-shaptools.spec
@@ -19,7 +19,7 @@
 # See also https://en.opensuse.org/openSUSE:Specfile_guidelines
 
 Name:           salt-shaptools
-Version:        0.3.1
+Version:        0.3.2
 Release:        0
 Summary:        Salt modules and states for SAP Applications and SLE-HA components management
 

--- a/tests/unit/states/test_crmshmod.py
+++ b/tests/unit/states/test_crmshmod.py
@@ -6,6 +6,7 @@
 # Import Python libs
 from __future__ import absolute_import, unicode_literals, print_function
 
+import sys
 from salt import exceptions
 
 # Import Salt Testing Libs
@@ -646,7 +647,13 @@ quorum {
         }
 
         output = crmshmod._convert2corosync(main_dict, '')
-        assert output == "a {\n\tb {\n\t\tf: 7\n\t}\n\tc: 2\n}\nd: 3\n"
+
+        # Py2 and py3 have different way of ordering the `items` method
+        # For the functionality this does not really affect
+        if sys.version_info[0] == 2:
+            assert output == "a {\n\tc: 2\n\tb {\n\t\tf: 7\n\t}\n}\nd: 3\n"
+        else:
+            assert output == "a {\n\tb {\n\t\tf: 7\n\t}\n\tc: 2\n}\nd: 3\n"
 
     @mock.patch('salt.states.crmshmod._convert2dict')
     @mock.patch('salt.states.crmshmod._mergedicts')

--- a/tests/unit/states/test_crmshmod.py
+++ b/tests/unit/states/test_crmshmod.py
@@ -15,6 +15,7 @@ from tests.support import mock
 from tests.support.mock import (
     NO_MOCK,
     NO_MOCK_REASON,
+    mock_open,
     MagicMock,
     patch
 )
@@ -480,3 +481,238 @@ class CrmshmodTestCase(TestCase, LoaderModuleMockMixin):
                 method='update',
                 url='file.config',
                 is_xml=False)
+
+    def test_convert2dict(self):
+        corofile = """
+# Please read the corosync.conf.5 manual page
+totem {
+    version: 2
+    max_messages: 20
+    interface {
+        ringnumber: 0
+
+    }
+    transport: udpu
+}
+
+logging {
+    timestamp: on
+    logger_subsys {
+        debug: off
+    }
+
+}
+
+quorum {
+    expected_votes: 1
+    two_node: 0
+}"""
+
+        corodict, _ = crmshmod._convert2dict(corofile.splitlines())
+
+        assert corodict == {
+            'totem': {
+                'version': '2',
+                'max_messages': '20',
+                'interface': {
+                    'ringnumber': '0'
+                },
+                'transport': 'udpu'
+            },
+            'logging': {
+                'timestamp': 'on',
+                'logger_subsys': {
+                    'debug': 'off'
+                }
+            },
+            'quorum': {
+                'expected_votes': '1',
+                'two_node': '0'
+            }
+        }
+
+    def test_merge_dicts1(self):
+        main_dict = {
+            'a': {
+                'b': 1,
+                'c': 2
+            },
+            'd': 3
+        }
+        changed_dict = {
+            'a': {
+                'c': 4
+            },
+            'd': 5
+        }
+        merged_dict, applied_changes = crmshmod._mergedicts(
+            main_dict, changed_dict, {}, '')
+
+        assert merged_dict == {
+            'a': {
+                'b': 1,
+                'c': 4
+            },
+            'd': 5
+        }
+
+        assert applied_changes == {
+            '.a.c': 4,
+            '.d': 5
+        }
+
+    def test_merge_dicts2(self):
+        main_dict = {
+            'a': {
+                'b': {
+                    'f': 7
+                },
+                'c': 2
+            },
+            'd': 3
+        }
+        changed_dict = {
+            'a': {
+                'b': {
+                    'f': 8
+                },
+            },
+            'd': 5
+        }
+        merged_dict, applied_changes = crmshmod._mergedicts(
+            main_dict, changed_dict, {}, '')
+
+        assert merged_dict == {
+            'a': {
+                'b': {
+                    'f': 8
+                },
+                'c': 2
+            },
+            'd': 5
+        }
+
+        assert applied_changes == {
+            '.d': 5,
+            '.a.b.f': 8
+        }
+
+    def test_merge_dicts3(self):
+        main_dict = {
+            'a': {
+                'b': 1,
+                'c': 2
+            },
+            'd': 3
+        }
+        changed_dict = {
+            'e': {
+                'c': 4
+            },
+            'a': {
+                'b': 3
+            },
+            'd': 5
+        }
+        merged_dict, applied_changes = crmshmod._mergedicts(
+            main_dict, changed_dict, {}, '')
+
+        assert merged_dict == {
+            'a': {
+                'b': 3,
+                'c': 2
+            },
+            'e': {
+                'c': 4
+            },
+            'd': 5
+        }
+
+        assert applied_changes == {
+            '.d': 5,
+            '.a.b': 3,
+            '.e': {'c': 4}
+        }
+
+    def test_convert2corosync(self):
+        main_dict = {
+            'a': {
+                'b': {
+                    'f': 7
+                },
+                'c': 2
+            },
+            'd': 3
+        }
+
+        output = crmshmod._convert2corosync(main_dict, '')
+        assert output == "a {\n\tb {\n\t\tf: 7\n\t}\n\tc: 2\n}\nd: 3\n"
+
+    @mock.patch('salt.states.crmshmod._convert2dict')
+    @mock.patch('salt.states.crmshmod._mergedicts')
+    def test_corosync_updated_already(self, mock_mergedicts, mock_convert2dict):
+        '''
+        Test to check corosync_updated when configuration is already applied
+        '''
+
+        ret = {'name': '/etc/corosync/corosync.conf',
+               'changes': {},
+               'result': True,
+               'comment': 'Corosync already has the required configuration'}
+
+        mock_convert2dict.return_value = ({'data': 1}, {})
+        mock_mergedicts.return_value = ({}, {})
+
+        file_content = "my corosync file content\nmy corosync file 2nd line content"
+        with patch("salt.utils.files.fopen", mock_open(read_data=file_content)):
+            assert crmshmod.corosync_updated(
+                name='/etc/corosync/corosync.conf',
+                data={'my_data': 1}) == ret
+
+        mock_convert2dict.assert_called_once_with(
+            ['my corosync file content', 'my corosync file 2nd line content']
+        )
+        mock_mergedicts.assert_called_once_with(
+            {'data': 1}, {'my_data': 1}, {})
+
+    @mock.patch('salt.states.crmshmod._convert2corosync')
+    @mock.patch('salt.states.crmshmod._convert2dict')
+    @mock.patch('salt.states.crmshmod._mergedicts')
+    def testt_corosync_updated(self, mock_mergedicts, mock_convert2dict, mock_convert2corosync):
+        '''
+        Test to check corosync_updated when configuration is applied
+        '''
+
+        ret = {'name': '/etc/corosync/corosync.conf',
+               'changes': {'change1': 1, 'change2': 2},
+               'result': True,
+               'comment': 'Corosync configuration file updated'}
+
+        mock_copy = MagicMock()
+        mock_write = MagicMock()
+        mock_convert2dict.return_value = ({'data': 1}, {})
+        mock_mergedicts.return_value = ({'updated': 2}, {'change1': 1, 'change2': 2})
+        mock_convert2corosync.return_value = 'new content'
+
+        file_content = "my corosync file content\nmy corosync file 2nd line content"
+
+        with patch.dict(crmshmod.__salt__, {'file.copy': mock_copy,
+                                            'file.write': mock_write}):
+            with patch("salt.utils.files.fopen", mock_open(read_data=file_content)):
+                assert crmshmod.corosync_updated(
+                    name='/etc/corosync/corosync.conf',
+                    data={'my_data': 1}) == ret
+
+        mock_convert2dict.assert_called_once_with(
+            ['my corosync file content', 'my corosync file 2nd line content']
+        )
+        mock_mergedicts.assert_called_once_with(
+            {'data': 1}, {'my_data': 1}, {})
+
+        mock_convert2corosync.assert_called_once_with({'updated': 2})
+
+        mock_copy.assert_called_once_with(
+            '/etc/corosync/corosync.conf', '/etc/corosync/corosync.conf.backup')
+
+        mock_write.assert_called_once_with(
+            '/etc/corosync/corosync.conf', 'new content')

--- a/tests/unit/states/test_crmshmod.py
+++ b/tests/unit/states/test_crmshmod.py
@@ -678,7 +678,7 @@ quorum {
     @mock.patch('salt.states.crmshmod._convert2corosync')
     @mock.patch('salt.states.crmshmod._convert2dict')
     @mock.patch('salt.states.crmshmod._mergedicts')
-    def testt_corosync_updated(self, mock_mergedicts, mock_convert2dict, mock_convert2corosync):
+    def test_corosync_updated(self, mock_mergedicts, mock_convert2dict, mock_convert2corosync):
         '''
         Test to check corosync_updated when configuration is applied
         '''


### PR DESCRIPTION
Implementation of the `corosync_updated` salt state.
This state changes the corosync configuration file with data coming in a dictionary.
To cover all the scenarios, the corosync conf file is converted to a dictionary, the change are applied, and the dictionary is converted back to the corosync conf file format.

This are the scenarios:
- If the coming data has a different value, the value is changed
- If the coming entry doesn't exist, the entry is created with the new value
- If the coming data exists and the values are the same, nothing is changed
- By default, it will create a backup file with the old configuration file