### PR TITLE
Feature/extract pydbapi

### DIFF
--- a/salt-shaptools.changes
+++ b/salt-shaptools.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Fri Mar 20 14:49:04 UTC 2020 - Xabier Arbulu <xarbulu@suse.com>
+
+- Version 0.3.3
+  * Add new salt state to extract the HANA python dbapi client 
+
+-------------------------------------------------------------------
 Thu Mar  5 10:03:39 UTC 2020 - Xabier Arbulu <xarbulu@suse.com>
 
 - Version 0.3.2

--- a/salt-shaptools.spec
+++ b/salt-shaptools.spec
@@ -19,7 +19,7 @@
 # See also https://en.opensuse.org/openSUSE:Specfile_guidelines
 
 Name:           salt-shaptools
-Version:        0.3.2
+Version:        0.3.3
 Release:        0
 Summary:        Salt modules and states for SAP Applications and SLE-HA components management
 

--- a/salt/modules/hanamod.py
+++ b/salt/modules/hanamod.py
@@ -27,9 +27,9 @@ import logging
 import time
 import re
 
-try:
+try:  # pragma: no cover
     import importlib as imp
-except ImportError:
+except ImportError:  # pragma: no cover
     import imp
 
 from salt import exceptions

--- a/salt/modules/hanamod.py
+++ b/salt/modules/hanamod.py
@@ -945,7 +945,7 @@ def _find_sap_folder(software_folders, folder_pattern):
                     return folder
                 else:
                     LOGGER.debug('%s folder does not containt HANA client', folder)
-        except FileNotFoundError:
+        except IOError:
             LOGGER.debug('%s file not found in %s. Skipping folder', LABEL_FILE, folder)
 
         labelidx = '{}/{}'.format(folder, LABELIDX_FILE)
@@ -958,7 +958,7 @@ def _find_sap_folder(software_folders, folder_pattern):
                     return _find_sap_folder(new_folders, folder_pattern)
                 except HanaClientNotFound:
                     continue
-        except FileNotFoundError:
+        except IOError:
             LOGGER.debug('%s file not found in %s. Skipping folder', LABELIDX_FILE, folder)
 
     raise HanaClientNotFound('HANA client not found')

--- a/salt/modules/hanamod.py
+++ b/salt/modules/hanamod.py
@@ -26,6 +26,7 @@ from __future__ import absolute_import, unicode_literals, print_function
 import logging
 import time
 import re
+import imp
 
 from salt import exceptions
 from salt.utils import files as salt_files
@@ -917,6 +918,14 @@ def wait_for_connection(
             'HANA database not available after {} seconds in {}:{}'.format(
                 timeout, host, port
             ))
+
+
+def reload_hdb_connector():
+    '''
+    As hdb_connector uses pyhdb or dbapi, if these packages are installed on the fly,
+    we need to reload the connector to import the correct api
+    '''
+    imp.reload(hdb_connector)
 
 
 def _find_sap_folder(software_folders, hana_client_pattern):

--- a/salt/modules/hanamod.py
+++ b/salt/modules/hanamod.py
@@ -26,6 +26,7 @@ from __future__ import absolute_import, unicode_literals, print_function
 import logging
 import time
 import re
+
 import imp
 
 from salt import exceptions
@@ -928,7 +929,7 @@ def reload_hdb_connector():
     imp.reload(hdb_connector)
 
 
-def _find_sap_folder(software_folders, hana_client_pattern):
+def _find_sap_folder(software_folders, folder_pattern):
     '''
     Find a SAP folder following a recursive approach using the LABEL and LABELIDX files
     '''
@@ -937,7 +938,7 @@ def _find_sap_folder(software_folders, hana_client_pattern):
         try:
             with salt_files.fopen(label, 'r') as label_file_ptr:
                 label_content = label_file_ptr.read().strip()
-                if hana_client_pattern.match(label_content):
+                if folder_pattern.match(label_content):
                     return folder
                 else:
                     LOGGER.debug('%s folder does not containt HANA client', folder)
@@ -951,7 +952,7 @@ def _find_sap_folder(software_folders, hana_client_pattern):
                 new_folders = [
                     '{}/{}'.format(folder, new_folder) for new_folder in labelidx_content]
                 try:
-                    return _find_sap_folder(new_folders, hana_client_pattern)
+                    return _find_sap_folder(new_folders, folder_pattern)
                 except HanaClientNotFound:
                     continue
         except FileNotFoundError:
@@ -982,6 +983,6 @@ def extract_pydbapi(
         hana_client_folder = _find_sap_folder(software_folders, hana_client_pattern)
     except HanaClientNotFound:
         raise exceptions.CommandExecutionError('HANA client not found')
-    hana_client_folder = '{}/client/{}'.format(hana_client_folder, name)
-    __salt__['archive.tar'](options='xvf', tarfile=hana_client_folder, dest=output_dir)
-    return hana_client_folder
+    pydbapi_file = '{}/client/{}'.format(hana_client_folder, name)
+    __salt__['archive.tar'](options='xvf', tarfile=pydbapi_file, dest=output_dir)
+    return pydbapi_file

--- a/salt/modules/hanamod.py
+++ b/salt/modules/hanamod.py
@@ -27,7 +27,10 @@ import logging
 import time
 import re
 
-import imp
+try:
+    import importlib as imp
+except ImportError:
+    import imp
 
 from salt import exceptions
 from salt.utils import files as salt_files

--- a/salt/modules/hanamod.py
+++ b/salt/modules/hanamod.py
@@ -886,17 +886,17 @@ def wait_for_connection(
     '''
     Wait until HANA is ready trying to connect to the database
 
-    host:
+    host
         Host where HANA is running
-    port:
+    port
         HANA database port
-    user:
+    user
         User to connect to the databse
-    password:
+    password
         Password to connect to the database
-    timeout:
+    timeout
         Timeout to try to connect to the database
-    interval:
+    interval
         Interval to try the connection
 
     CLI Example:
@@ -975,7 +975,9 @@ def extract_pydbapi(
     name
         Name of the package that needs to be installed
     software_folders
-        Folders where the
+        Folders list where the HANA client is located. It's used as a list as the pydbapi client
+        will be found automatically among different folders and providing several folders is a
+        standard way in SAP landscape
     output_dir
         Folder where the package is extracted
     '''

--- a/salt/states/hanamod.py
+++ b/salt/states/hanamod.py
@@ -790,6 +790,12 @@ def pydbapi_extracted(
             'extraction)'.format(output_dir)
         return ret
 
+    if __opts__['test']:
+        ret['result'] = None
+        ret['comment'] = '{} would be extracted'.format(name)
+        ret['changes']['output_dir'] = output_dir
+        return ret
+
     __salt__['file.mkdir'](output_dir)
 
     try:

--- a/salt/states/hanamod.py
+++ b/salt/states/hanamod.py
@@ -223,7 +223,7 @@ def installed(
             software_path=software_path,
             conf_file=TMP_CONFIG_FILE,
             root_user=root_user,
-            root_password=root_password)        
+            root_password=root_password)
         if hdb_pwd_file:
             __salt__['cp.get_file'](
                 path=hdb_pwd_file,
@@ -755,3 +755,49 @@ def memory_resources_updated(
     except exceptions.CommandExecutionError as err:
         ret['comment'] = six.text_type(err)
         return ret
+
+
+def pydbapi_extracted(
+        name,
+        software_folders,
+        output_dir,
+        hana_version='20',
+        force=False):
+    '''
+    Extract HANA pydbapi python client from the provided software folders
+
+    name
+        Name of the package that needs to be installed
+    software_folders
+        Folders where the
+    output_dir
+        Folder where the package is extracted
+    force
+        Force new extraction if the file already is extracted
+    '''
+
+    ret = {'name': name,
+           'changes': {},
+           'result': False,
+           'comment': ''}
+
+    if not force and __salt__['file.directory_exists'](output_dir):
+        ret['result'] = True
+        ret['comment'] = \
+            '{} already exists. Skipping extraction (set force to True to force the '\
+            'extraction)'.format(output_dir)
+        return ret
+
+    __salt__['file.mkdir'](output_dir)
+
+    try:
+        client = __salt__['hana.extract_pydbapi'](name, software_folders, output_dir, hana_version)
+    except exceptions.CommandExecutionError as err:
+        ret['comment'] = six.text_type(err)
+        return ret
+
+    ret['result'] = True
+    ret['comment'] = '{} correctly extracted'.format(client)
+    ret['changes'] = {'pydbapi': client, 'output_dir': output_dir}
+
+    return ret

--- a/salt/states/hanamod.py
+++ b/salt/states/hanamod.py
@@ -769,7 +769,9 @@ def pydbapi_extracted(
     name
         Name of the package that needs to be installed
     software_folders
-        Folders where the
+        Folders list where the HANA client is located. It's used as a list as the pydbapi client
+        will be found automatically among different folders and providing several folders is a
+        standard way in SAP landscape
     output_dir
         Folder where the package is extracted
     force

--- a/tests/unit/modules/test_hanamod.py
+++ b/tests/unit/modules/test_hanamod.py
@@ -826,7 +826,7 @@ class HanaModuleTest(TestCase, LoaderModuleMockMixin):
     def test_find_sap_folder_error(self, mock_fopen, mock_debug):
         mock_pattern = mock.Mock()
         mock_fopen.side_effect = [
-            FileNotFoundError, FileNotFoundError, FileNotFoundError, FileNotFoundError]
+            IOError, IOError, IOError, IOError]
         with pytest.raises(hanamod.HanaClientNotFound) as err:
             hanamod._find_sap_folder(['1234', '5678'], mock_pattern)
 
@@ -868,7 +868,7 @@ class HanaModuleTest(TestCase, LoaderModuleMockMixin):
         mock_pattern = mock.Mock()
         mock_pattern.match.side_effect = [False, False]
         with patch('salt.utils.files.fopen', mock_open(read_data=[
-                'data\n', 'DATA_UNITS\n', 'data_2\n', FileNotFoundError])) as mock_file:
+                'data\n', 'DATA_UNITS\n', 'data_2\n', IOError])) as mock_file:
             with pytest.raises(hanamod.HanaClientNotFound) as err:
                 folder = hanamod._find_sap_folder(['1234'], mock_pattern)
 

--- a/tests/unit/states/test_hanamod.py
+++ b/tests/unit/states/test_hanamod.py
@@ -262,7 +262,7 @@ class HanamodTestCase(TestCase, LoaderModuleMockMixin):
             assert hanamod.installed(
                 'prd', '00', 'pass', '/software',
                 'root', 'pass') == ret
-            
+
             mock_create.assert_called_once_with(
                 software_path='/software',
                 conf_file=hanamod.TMP_CONFIG_FILE,
@@ -1041,3 +1041,54 @@ class HanamodTestCase(TestCase, LoaderModuleMockMixin):
                 sid='prd',
                 inst='00',
                 password='pass')
+
+    def test_pydbapi_extracted_already_exists(self):
+        ret = {'name': 'PYDBAPI.tar',
+               'changes': {},
+               'result': True,
+               'comment': '/tmp/output already exists. Skipping extraction (set force to True to force the extraction)'}
+
+        mock_dir_exists = MagicMock(return_value=True)
+
+        with patch.dict(hanamod.__salt__, {'file.directory_exists': mock_dir_exists}):
+            assert hanamod.pydbapi_extracted(
+                'PYDBAPI.tar', ['1234', '5678'], '/tmp/output') == ret
+
+        mock_dir_exists.assert_called_once_with('/tmp/output')
+
+    def test_pydbapi_extracted_error(self):
+        ret = {'name': 'PYDBAPI.tar',
+               'changes': {},
+               'result': False,
+               'comment': 'error extracting'}
+
+        mock_mkdir = MagicMock()
+        mock_extract_pydbapi = MagicMock(
+            side_effect=exceptions.CommandExecutionError('error extracting'))
+
+        with patch.dict(hanamod.__salt__, {'file.mkdir': mock_mkdir,
+                                           'hana.extract_pydbapi': mock_extract_pydbapi}):
+            assert hanamod.pydbapi_extracted(
+                'PYDBAPI.tar', ['1234', '5678'], '/tmp/output', force=True) == ret
+
+        mock_mkdir.assert_called_once_with('/tmp/output')
+        mock_extract_pydbapi.assert_called_once_with(
+            'PYDBAPI.tar', ['1234', '5678'], '/tmp/output', '20')
+
+    def test_pydbapi_extracted_correct(self):
+        ret = {'name': 'PYDBAPI.tar',
+               'changes': {'pydbapi': 'py_client', 'output_dir': '/tmp/output'},
+               'result': True,
+               'comment': 'py_client correctly extracted'}
+
+        mock_mkdir = MagicMock()
+        mock_extract_pydbapi = MagicMock(return_value='py_client')
+
+        with patch.dict(hanamod.__salt__, {'file.mkdir': mock_mkdir,
+                                           'hana.extract_pydbapi': mock_extract_pydbapi}):
+            assert hanamod.pydbapi_extracted(
+                'PYDBAPI.tar', ['1234', '5678'], '/tmp/output', force=True) == ret
+
+        mock_mkdir.assert_called_once_with('/tmp/output')
+        mock_extract_pydbapi.assert_called_once_with(
+            'PYDBAPI.tar', ['1234', '5678'], '/tmp/output', '20')

--- a/tests/unit/states/test_hanamod.py
+++ b/tests/unit/states/test_hanamod.py
@@ -1056,6 +1056,16 @@ class HanamodTestCase(TestCase, LoaderModuleMockMixin):
 
         mock_dir_exists.assert_called_once_with('/tmp/output')
 
+    def test_pydbapi_extracted_test(self):
+        ret = {'name': 'PYDBAPI.tar',
+               'changes': {'output_dir': '/tmp/output'},
+               'result': None,
+               'comment': 'PYDBAPI.tar would be extracted'}
+
+        with patch.dict(hanamod.__opts__, {'test': True}):
+            assert hanamod.pydbapi_extracted(
+                'PYDBAPI.tar', ['1234', '5678'], '/tmp/output', force=True) == ret
+
     def test_pydbapi_extracted_error(self):
         ret = {'name': 'PYDBAPI.tar',
                'changes': {},


### PR DESCRIPTION
Some new salt methods to extract the python dbapi SAP package.
The method automatically finds the location of the package using the LABELIDX and LABEL files.

The `reload_hdb_connector` is a helper method to reload that library. Otherwise, during salt installation the recently installed py dbapi libraries are not available. It's a small trick to make everything work in the same python process (salt process basically)

Related to:
https://github.com/SUSE/saphanabootstrap-formula/pull/75
https://github.com/SUSE/sapnwbootstrap-formula/pull/42