### PR TITLE
Fix spec file with sapcar modules

### DIFF
--- a/salt-shaptools.spec
+++ b/salt-shaptools.spec
@@ -51,7 +51,8 @@ cp -R salt/modules/netweavermod.py %{buildroot}/srv/salt/_modules
 cp -R salt/states/netweavermod.py %{buildroot}/srv/salt/_states
 cp -R salt/modules/saptunemod.py %{buildroot}/srv/salt/_modules
 cp -R salt/states/saptunemod.py %{buildroot}/srv/salt/_states
-
+cp -R salt/modules/sapcarmod.py %{buildroot}/srv/salt/_modules
+cp -R salt/states/sapcarmod.py %{buildroot}/srv/salt/_states
 
 %files
 %defattr(-,root,root,-)


### PR DESCRIPTION
In the last PR adding sapcar functionality (https://github.com/SUSE/salt-shaptools/pull/59)
I did not update the `install` of package salt-shaptools. With this fix, I add the relevant sapcar modules files.