### PR TITLE
Feature/improve pydbapi extraction

### DIFF
--- a/salt-shaptools.changes
+++ b/salt-shaptools.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Fri May  8 23:37:02 UTC 2020 - Simranpal Singh <simranpal.singh@suse.com>
+
+- Version 0.3.5
+  * Add support to pass extra tar options
+
+-------------------------------------------------------------------
 Fri Mar 27 18:06:32 UTC 2020 - Simranpal Singh <simranpal.singh@suse.com>
 
 - Version 0.3.4

--- a/salt-shaptools.spec
+++ b/salt-shaptools.spec
@@ -19,7 +19,7 @@
 # See also https://en.opensuse.org/openSUSE:Specfile_guidelines
 
 Name:           salt-shaptools
-Version:        0.3.4
+Version:        0.3.5
 Release:        0
 Summary:        Salt modules and states for SAP Applications and SLE-HA components management
 

--- a/salt/modules/hanamod.py
+++ b/salt/modules/hanamod.py
@@ -970,6 +970,7 @@ def extract_pydbapi(
         name,
         software_folders,
         output_dir,
+        tar_options=None,
         hana_version='20'):
     '''
     Extract HANA pydbapi python client from the provided software folders
@@ -982,14 +983,21 @@ def extract_pydbapi(
         standard way in SAP landscape
     output_dir
         Folder where the package is extracted
+    extract_options
+        Additional options to pass to the tar extraction command
     '''
     current_platform = hana.HanaInstance.get_platform()
+    tar_options_str = '{} xvf'.format(tar_options) if tar_options else 'xvf'
     hana_client_pattern = re.compile('^HDB_CLIENT:{}.*:{}:.*'.format(
         hana_version, current_platform))
+    if not isinstance(software_folders, list):
+        raise TypeError(
+            "software_folders must be list, not {} type".format(type(software_folders).__name__)
+        )
     try:
         hana_client_folder = _find_sap_folder(software_folders, hana_client_pattern)
     except SapFolderNotFoundError:
         raise exceptions.CommandExecutionError('HANA client not found')
     pydbapi_file = '{}/client/{}'.format(hana_client_folder, name)
-    __salt__['archive.tar'](options='xvf', tarfile=pydbapi_file, dest=output_dir)
+    __salt__['archive.tar'](options=tar_options_str, tarfile=pydbapi_file, dest=output_dir)
     return pydbapi_file

--- a/salt/modules/hanamod.py
+++ b/salt/modules/hanamod.py
@@ -986,14 +986,14 @@ def extract_pydbapi(
     extract_options
         Additional options to pass to the tar extraction command
     '''
-    current_platform = hana.HanaInstance.get_platform()
-    tar_options_str = '{} xvf'.format(tar_options) if tar_options else 'xvf'
-    hana_client_pattern = re.compile('^HDB_CLIENT:{}.*:{}:.*'.format(
-        hana_version, current_platform))
     if not isinstance(software_folders, list):
         raise TypeError(
             "software_folders must be list, not {} type".format(type(software_folders).__name__)
         )
+    current_platform = hana.HanaInstance.get_platform()
+    tar_options_str = '{} xvf'.format(tar_options) if tar_options else 'xvf'
+    hana_client_pattern = re.compile('^HDB_CLIENT:{}.*:{}:.*'.format(
+        hana_version, current_platform))
     try:
         hana_client_folder = _find_sap_folder(software_folders, hana_client_pattern)
     except SapFolderNotFoundError:

--- a/salt/modules/hanamod.py
+++ b/salt/modules/hanamod.py
@@ -970,8 +970,8 @@ def extract_pydbapi(
         name,
         software_folders,
         output_dir,
-        tar_options=None,
-        hana_version='20'):
+        hana_version='20',
+        additional_extract_options=None):
     '''
     Extract HANA pydbapi python client from the provided software folders
 
@@ -983,15 +983,16 @@ def extract_pydbapi(
         standard way in SAP landscape
     output_dir
         Folder where the package is extracted
-    extract_options
+    additional_extract_options
         Additional options to pass to the tar extraction command
     '''
     if not isinstance(software_folders, list):
         raise TypeError(
-            'software_folders must be list, not {} type'.format(type(software_folders).__name__)
+            "software_folders must be list, not {} type".format(type(software_folders).__name__)
         )
     current_platform = hana.HanaInstance.get_platform()
-    tar_options_str = '{} xvf'.format(tar_options) if tar_options else 'xvf'
+    tar_options_str = ('{} xvf'.format(additional_extract_options)
+                       if additional_extract_options else 'xvf')
     hana_client_pattern = re.compile('^HDB_CLIENT:{}.*:{}:.*'.format(
         hana_version, current_platform))
     try:

--- a/salt/modules/hanamod.py
+++ b/salt/modules/hanamod.py
@@ -1000,5 +1000,5 @@ def extract_pydbapi(
     except SapFolderNotFoundError:
         raise exceptions.CommandExecutionError('HANA client not found')
     pydbapi_file = '{}/client/{}'.format(hana_client_folder, name)
-    __salt__['archive.tar'](options=tar_options_str, tarfile=pydbapi_file, dest=output_dir)
+    __salt__['archive.tar'](options=tar_options_str, tarfile=pydbapi_file, cwd=output_dir)
     return pydbapi_file

--- a/salt/modules/hanamod.py
+++ b/salt/modules/hanamod.py
@@ -991,8 +991,8 @@ def extract_pydbapi(
             "software_folders must be list, not {} type".format(type(software_folders).__name__)
         )
     current_platform = hana.HanaInstance.get_platform()
-    tar_options_str = ('{} xvf'.format(additional_extract_options)
-                       if additional_extract_options else 'xvf')
+    tar_options_str = ('{} -xvf'.format(additional_extract_options)
+                       if additional_extract_options else '-xvf')
     hana_client_pattern = re.compile('^HDB_CLIENT:{}.*:{}:.*'.format(
         hana_version, current_platform))
     try:

--- a/salt/modules/hanamod.py
+++ b/salt/modules/hanamod.py
@@ -988,7 +988,7 @@ def extract_pydbapi(
     '''
     if not isinstance(software_folders, list):
         raise TypeError(
-            "software_folders must be list, not {} type".format(type(software_folders).__name__)
+            'software_folders must be list, not {} type'.format(type(software_folders).__name__)
         )
     current_platform = hana.HanaInstance.get_platform()
     tar_options_str = '{} xvf'.format(tar_options) if tar_options else 'xvf'

--- a/salt/modules/hanamod.py
+++ b/salt/modules/hanamod.py
@@ -988,7 +988,7 @@ def extract_pydbapi(
     '''
     if not isinstance(software_folders, list):
         raise TypeError(
-            "software_folders must be list, not {} type".format(type(software_folders).__name__)
+            "software_folders must be a list, not {} type".format(type(software_folders).__name__)
         )
     current_platform = hana.HanaInstance.get_platform()
     tar_options_str = ('{} -xvf'.format(additional_extract_options)

--- a/salt/states/hanamod.py
+++ b/salt/states/hanamod.py
@@ -756,11 +756,11 @@ def memory_resources_updated(
         ret['comment'] = six.text_type(err)
         return ret
 
-
 def pydbapi_extracted(
         name,
         software_folders,
         output_dir,
+        tar_options=None,
         hana_version='20',
         force=False):
     '''
@@ -774,6 +774,8 @@ def pydbapi_extracted(
         standard way in SAP landscape
     output_dir
         Folder where the package is extracted
+    tar_options
+        Additional options to pass to the tar extraction command
     force
         Force new extraction if the file already is extracted
     '''
@@ -799,7 +801,12 @@ def pydbapi_extracted(
     __salt__['file.mkdir'](output_dir)
 
     try:
-        client = __salt__['hana.extract_pydbapi'](name, software_folders, output_dir, hana_version)
+        client = __salt__['hana.extract_pydbapi'](
+            name,
+            software_folders,
+            output_dir,
+            tar_options,
+            hana_version)
     except exceptions.CommandExecutionError as err:
         ret['comment'] = six.text_type(err)
         return ret

--- a/salt/states/hanamod.py
+++ b/salt/states/hanamod.py
@@ -756,13 +756,14 @@ def memory_resources_updated(
         ret['comment'] = six.text_type(err)
         return ret
 
+
 def pydbapi_extracted(
         name,
         software_folders,
         output_dir,
-        tar_options=None,
         hana_version='20',
-        force=False):
+        force=False,
+        additional_extract_options=None):
     '''
     Extract HANA pydbapi python client from the provided software folders
 
@@ -774,10 +775,10 @@ def pydbapi_extracted(
         standard way in SAP landscape
     output_dir
         Folder where the package is extracted
-    tar_options
-        Additional options to pass to the tar extraction command
     force
         Force new extraction if the file already is extracted
+    additional_extract_options
+        Additional options to pass to the tar extraction command
     '''
 
     ret = {'name': name,
@@ -805,8 +806,8 @@ def pydbapi_extracted(
             name,
             software_folders,
             output_dir,
-            tar_options,
-            hana_version)
+            hana_version,
+            additional_extract_options)
     except exceptions.CommandExecutionError as err:
         ret['comment'] = six.text_type(err)
         return ret

--- a/tests/unit/modules/test_hanamod.py
+++ b/tests/unit/modules/test_hanamod.py
@@ -892,13 +892,13 @@ class HanaModuleTest(TestCase, LoaderModuleMockMixin):
         mock_tar = MagicMock()
         with patch.dict(hanamod.__salt__, {'archive.tar': mock_tar}):
             pydbapi_file = hanamod.extract_pydbapi(
-                'PYDBAPI.tar.gz', ['1234', '5678'], '/tmp/output', additional_extract_options='l')
+                'PYDBAPI.tar.gz', ['1234', '5678'], '/tmp/output', additional_extract_options='-l')
 
         mock_compile.assert_called_once_with('^HDB_CLIENT:20.*:LINUX_X86_64:.*')
         mock_find_sap_folders.assert_called_once_with(
             ['1234', '5678'], compile_mocked)
         mock_tar.assert_called_once_with(
-            options='l xvf', tarfile='my_folder/client/PYDBAPI.tar.gz', dest='/tmp/output')
+            options='-l -xvf', tarfile='my_folder/client/PYDBAPI.tar.gz', dest='/tmp/output')
         assert pydbapi_file == 'my_folder/client/PYDBAPI.tar.gz'
 
     @mock.patch('re.compile')
@@ -911,7 +911,7 @@ class HanaModuleTest(TestCase, LoaderModuleMockMixin):
         mock_find_sap_folders.side_effect = hanamod.SapFolderNotFoundError
         with pytest.raises(exceptions.CommandExecutionError) as err:
             pydbapi_file = hanamod.extract_pydbapi(
-                'PYDBAPI.tar.gz', ['1234', '5678'], '/tmp/output', additional_extract_options='l')
+                'PYDBAPI.tar.gz', ['1234', '5678'], '/tmp/output', additional_extract_options='-l')
 
         mock_compile.assert_called_once_with('^HDB_CLIENT:20.*:LINUX_X86_64:.*')
         mock_find_sap_folders.assert_called_once_with(
@@ -922,6 +922,6 @@ class HanaModuleTest(TestCase, LoaderModuleMockMixin):
         software_folders = '1234'
         with pytest.raises(TypeError) as err:
             pydbapi_file = hanamod.extract_pydbapi(
-                'PYDBAPI.tar.gz', software_folders, '/tmp/output', additional_extract_options='l')
+                'PYDBAPI.tar.gz', software_folders, '/tmp/output', additional_extract_options='-l')
         assert 'software_folders must be list, not {} type'.format(
             type(software_folders).__name__) in str(err.value)

--- a/tests/unit/modules/test_hanamod.py
+++ b/tests/unit/modules/test_hanamod.py
@@ -898,7 +898,7 @@ class HanaModuleTest(TestCase, LoaderModuleMockMixin):
         mock_find_sap_folders.assert_called_once_with(
             ['1234', '5678'], compile_mocked)
         mock_tar.assert_called_once_with(
-            options='-l -xvf', tarfile='my_folder/client/PYDBAPI.tar.gz', dest='/tmp/output')
+            options='-l -xvf', tarfile='my_folder/client/PYDBAPI.tar.gz', cwd='/tmp/output')
         assert pydbapi_file == 'my_folder/client/PYDBAPI.tar.gz'
 
     @mock.patch('re.compile')

--- a/tests/unit/modules/test_hanamod.py
+++ b/tests/unit/modules/test_hanamod.py
@@ -923,5 +923,5 @@ class HanaModuleTest(TestCase, LoaderModuleMockMixin):
         with pytest.raises(TypeError) as err:
             pydbapi_file = hanamod.extract_pydbapi(
                 'PYDBAPI.tar.gz', software_folders, '/tmp/output', additional_extract_options='-l')
-        assert 'software_folders must be list, not {} type'.format(
+        assert 'software_folders must be a list, not {} type'.format(
             type(software_folders).__name__) in str(err.value)

--- a/tests/unit/modules/test_hanamod.py
+++ b/tests/unit/modules/test_hanamod.py
@@ -892,13 +892,13 @@ class HanaModuleTest(TestCase, LoaderModuleMockMixin):
         mock_tar = MagicMock()
         with patch.dict(hanamod.__salt__, {'archive.tar': mock_tar}):
             pydbapi_file = hanamod.extract_pydbapi(
-                'PYDBAPI.tar.gz', ['1234', '5678'], '/tmp/output', '-l')
+                'PYDBAPI.tar.gz', ['1234', '5678'], '/tmp/output', additional_extract_options='l')
 
         mock_compile.assert_called_once_with('^HDB_CLIENT:20.*:LINUX_X86_64:.*')
         mock_find_sap_folders.assert_called_once_with(
             ['1234', '5678'], compile_mocked)
         mock_tar.assert_called_once_with(
-            options='-l xvf', tarfile='my_folder/client/PYDBAPI.tar.gz', dest='/tmp/output')
+            options='l xvf', tarfile='my_folder/client/PYDBAPI.tar.gz', dest='/tmp/output')
         assert pydbapi_file == 'my_folder/client/PYDBAPI.tar.gz'
 
     @mock.patch('re.compile')
@@ -911,7 +911,7 @@ class HanaModuleTest(TestCase, LoaderModuleMockMixin):
         mock_find_sap_folders.side_effect = hanamod.SapFolderNotFoundError
         with pytest.raises(exceptions.CommandExecutionError) as err:
             pydbapi_file = hanamod.extract_pydbapi(
-                'PYDBAPI.tar.gz', ['1234', '5678'], '/tmp/output', '-l')
+                'PYDBAPI.tar.gz', ['1234', '5678'], '/tmp/output', additional_extract_options='l')
 
         mock_compile.assert_called_once_with('^HDB_CLIENT:20.*:LINUX_X86_64:.*')
         mock_find_sap_folders.assert_called_once_with(
@@ -922,6 +922,6 @@ class HanaModuleTest(TestCase, LoaderModuleMockMixin):
         software_folders = '1234'
         with pytest.raises(TypeError) as err:
             pydbapi_file = hanamod.extract_pydbapi(
-                'PYDBAPI.tar.gz', software_folders, '/tmp/output', '-l')
+                'PYDBAPI.tar.gz', software_folders, '/tmp/output', additional_extract_options='l')
         assert 'software_folders must be list, not {} type'.format(
             type(software_folders).__name__) in str(err.value)

--- a/tests/unit/modules/test_hanamod.py
+++ b/tests/unit/modules/test_hanamod.py
@@ -919,7 +919,9 @@ class HanaModuleTest(TestCase, LoaderModuleMockMixin):
         assert 'HANA client not found' in str(err.value)
 
     def test_extract_pydbapi_software_folders_type_error(self):
+        software_folders = '1234'
         with pytest.raises(TypeError) as err:
             pydbapi_file = hanamod.extract_pydbapi(
-                'PYDBAPI.tar.gz','1234', '/tmp/output', '-l')
-        assert 'software_folders must be list, not str type' in str(err.value)
+                'PYDBAPI.tar.gz', software_folders, '/tmp/output', '-l')
+        assert 'software_folders must be list, not {} type'.format(
+            type(software_folders).__name__) in str(err.value)

--- a/tests/unit/states/test_hanamod.py
+++ b/tests/unit/states/test_hanamod.py
@@ -1079,11 +1079,11 @@ class HanamodTestCase(TestCase, LoaderModuleMockMixin):
         with patch.dict(hanamod.__salt__, {'file.mkdir': mock_mkdir,
                                            'hana.extract_pydbapi': mock_extract_pydbapi}):
             assert hanamod.pydbapi_extracted(
-                'PYDBAPI.tar', ['1234', '5678'], '/tmp/output', force=True) == ret
+                'PYDBAPI.tar', ['1234', '5678'], '/tmp/output', '-l', force=True) == ret
 
         mock_mkdir.assert_called_once_with('/tmp/output')
         mock_extract_pydbapi.assert_called_once_with(
-            'PYDBAPI.tar', ['1234', '5678'], '/tmp/output', '20')
+            'PYDBAPI.tar', ['1234', '5678'], '/tmp/output', '-l', '20')
 
     def test_pydbapi_extracted_correct(self):
         ret = {'name': 'PYDBAPI.tar',
@@ -1097,8 +1097,8 @@ class HanamodTestCase(TestCase, LoaderModuleMockMixin):
         with patch.dict(hanamod.__salt__, {'file.mkdir': mock_mkdir,
                                            'hana.extract_pydbapi': mock_extract_pydbapi}):
             assert hanamod.pydbapi_extracted(
-                'PYDBAPI.tar', ['1234', '5678'], '/tmp/output', force=True) == ret
+                'PYDBAPI.tar', ['1234', '5678'], '/tmp/output', '-l', force=True) == ret
 
         mock_mkdir.assert_called_once_with('/tmp/output')
         mock_extract_pydbapi.assert_called_once_with(
-            'PYDBAPI.tar', ['1234', '5678'], '/tmp/output', '20')
+            'PYDBAPI.tar', ['1234', '5678'], '/tmp/output', '-l', '20')

--- a/tests/unit/states/test_hanamod.py
+++ b/tests/unit/states/test_hanamod.py
@@ -1080,11 +1080,11 @@ class HanamodTestCase(TestCase, LoaderModuleMockMixin):
                                            'hana.extract_pydbapi': mock_extract_pydbapi}):
             assert hanamod.pydbapi_extracted(
                 'PYDBAPI.tar', ['1234', '5678'], '/tmp/output',
-                additional_extract_options='l', force=True) == ret
+                additional_extract_options='-l', force=True) == ret
 
         mock_mkdir.assert_called_once_with('/tmp/output')
         mock_extract_pydbapi.assert_called_once_with(
-            'PYDBAPI.tar', ['1234', '5678'], '/tmp/output', '20', 'l')
+            'PYDBAPI.tar', ['1234', '5678'], '/tmp/output', '20', '-l')
 
     def test_pydbapi_extracted_correct(self):
         ret = {'name': 'PYDBAPI.tar',
@@ -1099,8 +1099,8 @@ class HanamodTestCase(TestCase, LoaderModuleMockMixin):
                                            'hana.extract_pydbapi': mock_extract_pydbapi}):
             assert hanamod.pydbapi_extracted(
                 'PYDBAPI.tar', ['1234', '5678'], '/tmp/output',
-                force=True, additional_extract_options='l') == ret
+                force=True, additional_extract_options='-l') == ret
 
         mock_mkdir.assert_called_once_with('/tmp/output')
         mock_extract_pydbapi.assert_called_once_with(
-            'PYDBAPI.tar', ['1234', '5678'], '/tmp/output', '20', 'l')
+            'PYDBAPI.tar', ['1234', '5678'], '/tmp/output', '20', '-l')

--- a/tests/unit/states/test_hanamod.py
+++ b/tests/unit/states/test_hanamod.py
@@ -1098,7 +1098,7 @@ class HanamodTestCase(TestCase, LoaderModuleMockMixin):
         with patch.dict(hanamod.__salt__, {'file.mkdir': mock_mkdir,
                                            'hana.extract_pydbapi': mock_extract_pydbapi}):
             assert hanamod.pydbapi_extracted(
-                'PYDBAPI.tar', ['1234', '5678'], '/tmp/output', 
+                'PYDBAPI.tar', ['1234', '5678'], '/tmp/output',
                 force=True, additional_extract_options='l') == ret
 
         mock_mkdir.assert_called_once_with('/tmp/output')

--- a/tests/unit/states/test_hanamod.py
+++ b/tests/unit/states/test_hanamod.py
@@ -150,7 +150,7 @@ class HanamodTestCase(TestCase, LoaderModuleMockMixin):
                                            'cp.get_file': mock_cp,
                                            'file.move': mock_mv,
                                            'hana.create_conf_file': mock_create_xml,
-                                           'hana.update_hdb_pwd_file':mock_update_xml,
+                                           'hana.update_hdb_pwd_file': mock_update_xml,
                                            'hana.update_conf_file': mock_update,
                                            'hana.install': mock_install,
                                            'file.remove': mock_remove}):
@@ -1079,11 +1079,12 @@ class HanamodTestCase(TestCase, LoaderModuleMockMixin):
         with patch.dict(hanamod.__salt__, {'file.mkdir': mock_mkdir,
                                            'hana.extract_pydbapi': mock_extract_pydbapi}):
             assert hanamod.pydbapi_extracted(
-                'PYDBAPI.tar', ['1234', '5678'], '/tmp/output', '-l', force=True) == ret
+                'PYDBAPI.tar', ['1234', '5678'], '/tmp/output',
+                additional_extract_options='l', force=True) == ret
 
         mock_mkdir.assert_called_once_with('/tmp/output')
         mock_extract_pydbapi.assert_called_once_with(
-            'PYDBAPI.tar', ['1234', '5678'], '/tmp/output', '-l', '20')
+            'PYDBAPI.tar', ['1234', '5678'], '/tmp/output', '20', 'l')
 
     def test_pydbapi_extracted_correct(self):
         ret = {'name': 'PYDBAPI.tar',
@@ -1097,8 +1098,9 @@ class HanamodTestCase(TestCase, LoaderModuleMockMixin):
         with patch.dict(hanamod.__salt__, {'file.mkdir': mock_mkdir,
                                            'hana.extract_pydbapi': mock_extract_pydbapi}):
             assert hanamod.pydbapi_extracted(
-                'PYDBAPI.tar', ['1234', '5678'], '/tmp/output', '-l', force=True) == ret
+                'PYDBAPI.tar', ['1234', '5678'], '/tmp/output', 
+                force=True, additional_extract_options='l') == ret
 
         mock_mkdir.assert_called_once_with('/tmp/output')
         mock_extract_pydbapi.assert_called_once_with(
-            'PYDBAPI.tar', ['1234', '5678'], '/tmp/output', '-l', '20')
+            'PYDBAPI.tar', ['1234', '5678'], '/tmp/output', '20', 'l')


### PR DESCRIPTION
This PR brings two changes to pydbapi extraction functions:
-Add support for tar options
-Raise error when `software_folders` parameter to the functions is when not passed as list type

Also Added the UT for this change and updated the existing UTs

Note that I have added the extra tar options preceeding the `xvf` extract option which requires `xvf tarfile` together

Salt tar functionality:  https://github.com/saltstack/salt/blob/779bc179e25be49d3449a56648bf827bcb6d5fb6/salt/modules/archive.py#L466

Todo: update spec file, change log