### PR TITLE
Hotfix/fix sbd usage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -56,14 +56,12 @@ jobs:
 
       script:
         - |
-          docker run -t -v "$(pwd):/package" \
-          -e OBS_USER=$OBS_USER \
-          -e OBS_PASS=$OBS_PASS \
-          -e FOLDER=$FOLDER \
-          -e OBS_PROJECT=$OBS_PROJECT \
-          -e PACKAGE_NAME=$PACKAGE_NAME \
+          docker run -t -v "$(pwd):/package" -w /package \
+          -e OBS_USER -e OBS_PASS -e FOLDER -e OBS_PROJECT -e PACKAGE_NAME \
           shap/continuous_deliver \
-          /bin/bash -c "cd /package;/scripts/upload.sh"
+          /bin/bash -c "sed -i 's~%%VERSION%%~$TRAVIS_COMMIT~' _service && \
+          sed -i 's~%%REPOSITORY%%~$TRAVIS_REPO_SLUG~' _service && \
+          /scripts/upload.sh"
 
     - stage: submit
       if: type != pull_request AND branch = master
@@ -75,11 +73,6 @@ jobs:
 
       script:
         - |
-          docker run -t -v "$(pwd):/package" \
-          -e OBS_USER=$OBS_USER \
-          -e OBS_PASS=$OBS_PASS \
-          -e OBS_PROJECT=$OBS_PROJECT \
-          -e PACKAGE_NAME=$PACKAGE_NAME \
-          -e TARGET_PROJECT=$TARGET_PROJECT \
-          shap/continuous_deliver \
-          /bin/bash -c "cd /package;/scripts/submit.sh"
+          docker run -t -v "$(pwd):/package" -w /package \
+          -e OBS_USER -e OBS_PASS -e OBS_PROJECT -e PACKAGE_NAME -e TARGET_PROJECT shap/continuous_deliver \
+          /scripts/submit.sh

--- a/_service
+++ b/_service
@@ -1,0 +1,19 @@
+<services>
+  <service name="tar_scm" mode="disabled">
+    <param name="url">https://github.com/%%REPOSITORY%%.git</param>
+    <param name="scm">git</param>
+    <param name="exclude">.git</param>
+    <param name="filename">salt-shaptools</param>
+    <param name="versionformat">0.3.7+git.%ct.%h</param>
+    <param name="revision">%%VERSION%%</param>
+  </service>
+
+  <service name="recompress" mode="disabled">
+    <param name="file">*.tar</param>
+    <param name="compression">gz</param>
+  </service>
+
+  <service name="set_version" mode="disabled">
+    <param name="basename">salt-shaptools</param>
+  </service>
+</services>

--- a/salt-shaptools.changes
+++ b/salt-shaptools.changes
@@ -1,4 +1,12 @@
 -------------------------------------------------------------------
+Thu Jun  4 09:17:52 UTC 2020 - Xabier Arbulu <xarbulu@suse.com>
+
+- Version 0.3.7
+  * Make diskless sbd and using disks self exclusive (bsc#1172432)
+
+  (jsc#ECO-1965, jsc#SLE-4047)
+
+-------------------------------------------------------------------
 Thu May 21 10:14:22 UTC 2020 - Xabier Arbulu <xarbulu@suse.com>
 
 - Version 0.3.6

--- a/salt-shaptools.spec
+++ b/salt-shaptools.spec
@@ -19,7 +19,7 @@
 # See also https://en.opensuse.org/openSUSE:Specfile_guidelines
 
 Name:           salt-shaptools
-Version:        0.3.7
+Version:        0
 Release:        0
 Summary:        Salt modules and states for SAP Applications and SLE-HA components management
 

--- a/salt-shaptools.spec
+++ b/salt-shaptools.spec
@@ -19,7 +19,7 @@
 # See also https://en.opensuse.org/openSUSE:Specfile_guidelines
 
 Name:           salt-shaptools
-Version:        0.3.6
+Version:        0.3.7
 Release:        0
 Summary:        Salt modules and states for SAP Applications and SLE-HA components management
 

--- a/salt/states/crmshmod.py
+++ b/salt/states/crmshmod.py
@@ -121,10 +121,10 @@ def cluster_initialized(
     admin_ip
         Virtual IP address. If None the virtual address is not set
     sbd
-        Enable sbd usage. If None sbd is not set
+        Enable sbd diskless
+        sbd and sbd_dev are self exclusive. If both are used by any case sbd_dev will be used
     sbd_dev
-        sbd device path. To be used "sbd" parameter must be used too. If None,
-            the sbd is set as diskless.
+        sbd device path
         This parameter can be a string (meaning one disk) or a list with multiple disks
     no_overwrite_sshkey
         No overwrite the currently existing sshkey (/root/.ssh/id_rsa)

--- a/tests/unit/modules/test_crmshmod.py
+++ b/tests/unit/modules/test_crmshmod.py
@@ -356,8 +356,19 @@ class CrmshModuleTest(TestCase, LoaderModuleMockMixin):
             assert result
             mock_cmd_run.assert_called_once_with(
                 '{} cluster init -y -n {} -w {} -i {} -u -A {} '
-                '--enable-sbd -s {} -s {} --no-overwrite-sshkey -q'.format(
+                '-s {} -s {} --no-overwrite-sshkey -q'.format(
                     crmshmod.CRM_COMMAND, 'hacluster', 'dog', 'eth1', '192.168.1.50', 'dev1', 'dev2'))
+
+        # SBD diskless
+        mock_cmd_run.reset_mock()
+        with patch.dict(crmshmod.__salt__, {'cmd.retcode': mock_cmd_run}):
+            result = crmshmod._crm_init(
+                'hacluster', 'dog', 'eth1', True, '192.168.1.50', True, None, True, True)
+            assert result
+            mock_cmd_run.assert_called_once_with(
+                '{} cluster init -y -n {} -w {} -i {} -u -A {} '
+                '-S --no-overwrite-sshkey -q'.format(
+                    crmshmod.CRM_COMMAND, 'hacluster', 'dog', 'eth1', '192.168.1.50'))
 
     def test_ha_cluster_init_basic(self):
         '''
@@ -392,119 +403,61 @@ class CrmshModuleTest(TestCase, LoaderModuleMockMixin):
             mock_corosync.assert_called_once_with('1.0.1.0', 'node')
             mock_interface_ip.assert_called_once_with('eth1')
             mock_cmd_run.assert_called_once_with(
-                '{} -y -i {} -A {} -S -s {} -s {} -q'.format(
+                '{} -y -i {} -A {} -s {} -s {} -q'.format(
                     crmshmod.HA_INIT_COMMAND, 'eth1', '192.168.1.50', 'dev1', 'dev2'))
 
-    def test_manage_multiple_sbd(self):
-
-        sbd, devs = crmshmod._manage_multiple_sbd(None, None)
-        assert sbd is None
-        assert devs is None
-
-        sbd, devs = crmshmod._manage_multiple_sbd(True, 'disk')
-        assert sbd is True
-        assert devs == ['disk']
-
-    def test_manage_multiple_sbd_workaround(self):
-
-        mock_cmd_run = MagicMock(side_effect=[0, 0])
-        mock_file_replace = MagicMock(return_code=0)
-
+        # SBD diskless
+        mock_cmd_run.reset_mock()
         with patch.dict(crmshmod.__salt__, {
                 'cmd.retcode': mock_cmd_run,
-                'file.replace': mock_file_replace}):
-            sbd, devs = crmshmod._manage_multiple_sbd(True, ['disk1', 'disk2'])
+                'network.get_hostname': mock_get_hostname,
+                'network.interface_ip': mock_interface_ip}):
+            result = crmshmod._ha_cluster_init(
+                'dog', 'eth1', True, '192.168.1.50', True, None, True)
+            assert result == 0
+            mock_cmd_run.assert_called_once_with(
+                '{} -y -i {} -A {} -S -q'.format(
+                    crmshmod.HA_INIT_COMMAND, 'eth1', '192.168.1.50'))
 
-        mock_cmd_run.assert_has_calls([
-            mock.call('sbd -d disk1 -d disk2 create'),
-            mock.call('{} cluster init sbd -s {}'.format(crmshmod.CRM_COMMAND, 'disk1'))
-        ])
-        mock_file_replace.assert_called_once_with(
-            path='/etc/sysconfig/sbd',
-            pattern='^SBD_DEVICE=.*',
-            repl='SBD_DEVICE={}'.format(';'.join(['disk1', 'disk2'])),
-            append_if_not_found=True
-        )
-        assert sbd is None
-        assert devs is None
-
-    def test_manage_multiple_sbd_workaround_errors(self):
-
-        mock_cmd_run = MagicMock(side_effect=[1, 0])
-
-        with patch.dict(crmshmod.__salt__, {
-                'cmd.retcode': mock_cmd_run}):
-            with pytest.raises(exceptions.SaltInvocationError) as err:
-                crmshmod._manage_multiple_sbd(True, ['disk1', 'disk2'])
-
-        assert 'sbd disks could not be formatted properly' in str(err.value)
-        mock_cmd_run.assert_called_once_with('sbd -d disk1 -d disk2 create')
-
-        mock_cmd_run = MagicMock(side_effect=[0, 1])
-
-        with patch.dict(crmshmod.__salt__, {
-                'cmd.retcode': mock_cmd_run}):
-            with pytest.raises(exceptions.SaltInvocationError) as err:
-                crmshmod._manage_multiple_sbd(True, ['disk1', 'disk2'])
-
-        assert 'crm cluster init sbd failed' in str(err.value)
-        mock_cmd_run.assert_has_calls([
-            mock.call('sbd -d disk1 -d disk2 create'),
-            mock.call('{} cluster init sbd -s {}'.format(crmshmod.CRM_COMMAND, 'disk1'))
-        ])
-
-    @mock.patch('salt.modules.crmshmod._manage_multiple_sbd')
     @mock.patch('salt.modules.crmshmod._crm_init')
-    def test_cluster_init_crm(self, crm_init, manage_sbd):
+    def test_cluster_init_crm(self, crm_init):
         '''
         Test cluster_init with crm option
         '''
 
-        manage_sbd.return_value = ('sbd', 'devs')
-
         with patch.dict(crmshmod.__salt__, {'crm.use_crm': True}):
             crm_init.return_value = 0
-            value = crmshmod.cluster_init('hacluster', 'dog', 'eth1')
+            value = crmshmod.cluster_init('hacluster', 'dog', 'eth1', sbd=True, sbd_dev='dev1')
             assert value == 0
             crm_init.assert_called_once_with(
-                'hacluster', 'dog', 'eth1', None, None, 'sbd', 'devs', False, None)
-            crm_init.reset_mock()
+                'hacluster', 'dog', 'eth1', None, None, True, ['dev1'], False, None)
 
+        crm_init.reset_mock()
         with patch.dict(crmshmod.__salt__, {'crm.use_crm': True}):
             crm_init.return_value = 0
-            value = crmshmod.cluster_init('hacluster', 'dog', 'eth1', sbd_dev=['disk1', 'disk2'])
+            value = crmshmod.cluster_init('hacluster', 'dog', 'eth1', sbd=False, sbd_dev=['disk1', 'disk2'])
             assert value == 0
             crm_init.assert_called_once_with(
-                'hacluster', 'dog', 'eth1', None, None, 'sbd', 'devs', False, None)
-            crm_init.reset_mock()
-
-        with patch.dict(crmshmod.__salt__, {'crm.use_crm': True}):
-            crm_init.return_value = 0
-            value = crmshmod.cluster_init('hacluster', 'dog', 'eth1', sbd_dev='disk1')
-            assert value == 0
-            crm_init.assert_called_once_with(
-                'hacluster', 'dog', 'eth1', None, None, 'sbd', 'devs', False, None)
+                'hacluster', 'dog', 'eth1', None, None, False, ['disk1', 'disk2'], False, None)
 
     @mock.patch('logging.Logger.warning')
-    @mock.patch('salt.modules.crmshmod._manage_multiple_sbd')
     @mock.patch('salt.modules.crmshmod._ha_cluster_init')
-    def test_cluster_init_ha(self, ha_cluster_init, manage_sbd, logger):
+    def test_cluster_init_ha(self, ha_cluster_init, logger):
         '''
         Test cluster_init with ha_cluster_init option
         '''
-        manage_sbd.return_value = ('sbd', 'devs')
 
         with patch.dict(crmshmod.__salt__, {'crm.use_crm': False}):
             ha_cluster_init.return_value = 0
             value = crmshmod.cluster_init(
-                'hacluster', 'dog', 'eth1', no_overwrite_sshkey=True)
+                'hacluster', 'dog', 'eth1', sbd_dev='dev1', no_overwrite_sshkey=True)
             assert value == 0
             logger.assert_has_calls([
                 mock.call('The parameter name is not considered!'),
                 mock.call('--no_overwrite_sshkey option not available')
             ])
             ha_cluster_init.assert_called_once_with(
-                'dog', 'eth1', None, None, 'sbd', 'devs', None)
+                'dog', 'eth1', None, None, None, ['dev1'], None)
 
     def test_crm_join_basic(self):
         '''


### PR DESCRIPTION
Fix https://bugzilla.suse.com/show_bug.cgi?id=1172432

Now `-s` and `-S` are self exclusive.
I would like to change the `sbd` parameter by `sbd_diskless`, but this means a non backward compatible change, so by now I won't change it. What do you think? Now that salt-shaptools is used by more people this changes are not so easy to add.
Besides that I have removed the `manage_multiple_sbd` as this is done by crmsh now properly.