### PR TITLE
Retry get json status when estimation sync time not calculated yet.

### DIFF
--- a/_service
+++ b/_service
@@ -4,7 +4,7 @@
     <param name="scm">git</param>
     <param name="exclude">.git</param>
     <param name="filename">salt-shaptools</param>
-    <param name="versionformat">0.3.7+git.%ct.%h</param>
+    <param name="versionformat">0.3.8+git.%ct.%h</param>
     <param name="revision">%%VERSION%%</param>
   </service>
 

--- a/salt-shaptools.changes
+++ b/salt-shaptools.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Fri Jun  5 07:46:01 UTC 2020 - nick wang <nwang@suse.com>
+
+- Version 0.3.8
+  * DRBD: Avoid CommandExecutionError when estimation sync time not ready
+
+-------------------------------------------------------------------
 Thu Jun  4 09:17:52 UTC 2020 - Xabier Arbulu <xarbulu@suse.com>
 
 - Version 0.3.7

--- a/salt-shaptools.spec
+++ b/salt-shaptools.spec
@@ -19,7 +19,7 @@
 # See also https://en.opensuse.org/openSUSE:Specfile_guidelines
 
 Name:           salt-shaptools
-Version:        0.3.8
+Version:        0
 Release:        0
 Summary:        Salt modules and states for SAP Applications and SLE-HA components management
 

--- a/salt-shaptools.spec
+++ b/salt-shaptools.spec
@@ -1,7 +1,7 @@
 #
 # spec file for package salt-shaptools
 #
-# Copyright (c) 2019 SUSE LLC
+# Copyright (c) 2020 SUSE LLC
 #
 # All modifications and additions to the file contributed by third parties
 # remain the property of their copyright owners, unless otherwise agreed
@@ -19,12 +19,12 @@
 # See also https://en.opensuse.org/openSUSE:Specfile_guidelines
 
 Name:           salt-shaptools
-Version:        0
+Version:        0.3.8
 Release:        0
 Summary:        Salt modules and states for SAP Applications and SLE-HA components management
 
 License:        Apache-2.0
-Url:            https://github.com/SUSE/%{name}
+URL:            https://github.com/SUSE/%{name}
 Source0:        %{name}-%{version}.tar.gz
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build
 BuildArch:      noarch


### PR DESCRIPTION
Estimation sync time still need to be calculated based
on the synced data. Though less than a sec,
`drbdsetup status --json` will return an invalid json
format `"estimated-seconds-to-finish": nan,` when not ready.