### PR TITLE
hana: Fix imp reload usage in py2

### DIFF
--- a/_service
+++ b/_service
@@ -4,7 +4,7 @@
     <param name="scm">git</param>
     <param name="exclude">.git</param>
     <param name="filename">salt-shaptools</param>
-    <param name="versionformat">0.3.8+git.%ct.%h</param>
+    <param name="versionformat">0.3.9+git.%ct.%h</param>
     <param name="revision">%%VERSION%%</param>
   </service>
 

--- a/salt-shaptools.changes
+++ b/salt-shaptools.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Tue Jun  9 13:08:47 UTC 2020 - Xabier Arbulu <xarbulu@suse.com>
+
+- Version 0.3.9
+  * hana: Fix imp reload usage in py2
+
+-------------------------------------------------------------------
 Fri Jun  5 07:46:01 UTC 2020 - nick wang <nwang@suse.com>
 
 - Version 0.3.8

--- a/salt/modules/hanamod.py
+++ b/salt/modules/hanamod.py
@@ -27,10 +27,11 @@ import logging
 import time
 import re
 
+# Make imp.reload available for py3 and py2
 try:  # pragma: no cover
-    import importlib as imp
+    from importlib import reload as imp_reload
 except ImportError:  # pragma: no cover
-    import imp
+    from imp import reload as imp_reload
 
 from salt import exceptions
 from salt.utils import files as salt_files
@@ -929,7 +930,7 @@ def reload_hdb_connector():
     As hdb_connector uses pyhdb or dbapi, if these packages are installed on the fly,
     we need to reload the connector to import the correct api
     '''
-    imp.reload(hdb_connector)
+    imp_reload(hdb_connector)
 
 
 def _find_sap_folder(software_folders, folder_pattern):

--- a/tests/unit/modules/test_hanamod.py
+++ b/tests/unit/modules/test_hanamod.py
@@ -816,7 +816,7 @@ class HanaModuleTest(TestCase, LoaderModuleMockMixin):
         assert 'HANA database not available after 2 seconds in 192.168.10.15:30015' in str(err.value)
 
     @mock.patch('salt.modules.hanamod.hdb_connector')
-    @mock.patch('importlib.reload')
+    @mock.patch('salt.modules.hanamod.imp_reload')
     def test_reload_hdb_connector(self, mock_reload, mock_hdb_connector):
         hanamod.reload_hdb_connector()
         mock_reload.assert_called_once_with(mock_hdb_connector)


### PR DESCRIPTION
The `reload_hdb_connector` method in py2 was not working, as the `importlib.reload` method doesn't exist.
Now the code imports the correct reload from `importlib/imp` depending on the python version.
I will run tests now for py2 and py3.