### PR TITLE
hana: Fix imp reload usage in py2

### DIFF
--- a/_service
+++ b/_service
@@ -4,7 +4,7 @@
     <param name="scm">git</param>
     <param name="exclude">.git</param>
     <param name="filename">salt-shaptools</param>
-    <param name="versionformat">0.3.8+git.%ct.%h</param>
+    <param name="versionformat">0.3.9+git.%ct.%h</param>
     <param name="revision">%%VERSION%%</param>
   </service>
 

--- a/salt-shaptools.changes
+++ b/salt-shaptools.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Tue Jun  9 13:08:47 UTC 2020 - Xabier Arbulu <xarbulu@suse.com>
+
+- Version 0.3.9
+  * hana: Fix imp reload usage in py2
+
+-------------------------------------------------------------------
 Fri Jun  5 07:46:01 UTC 2020 - nick wang <nwang@suse.com>
 
 - Version 0.3.8


### PR DESCRIPTION
Hi,
I'm overwritting the PR we closed before as it was not fixing the issue finally.
I have been forced to do some python tricks to load the `dbapi` code properly in python 2.

This time I have tested and it works fine in SLE12 SP4 (py2) and SLE15 SP1 (py3)