### PR TITLE
Fix extra_parameters usage in hana.installed

### DIFF
--- a/tests/unit/states/test_hanamod.py
+++ b/tests/unit/states/test_hanamod.py
@@ -158,7 +158,7 @@ class HanamodTestCase(TestCase, LoaderModuleMockMixin):
                 'prd', '00', 'pass', '/software',
                 'root', config_file='hana.conf', root_password='Test1234',
                 sapadm_password='Test1234', system_user_password='Test1234',
-                extra_parameters=[{'hostname': 'hana01'}]) == ret
+                extra_parameters=[{'hostname': 'hana01', 'org_manager_password': 'pass'}]) == ret
 
             mock_create_xml.assert_called_once_with(
                 software_path='/software',
@@ -170,13 +170,14 @@ class HanamodTestCase(TestCase, LoaderModuleMockMixin):
                 dst=hanamod.TMP_HDB_PWD_FILE)
             mock_update_xml.assert_called_once_with(
                 hdb_pwd_file=hanamod.TMP_HDB_PWD_FILE, root_password='Test1234',
-                password='pass', sapadm_password='Test1234', system_user_password='Test1234')
+                password='pass', sapadm_password='Test1234', system_user_password='Test1234',
+                org_manager_password='pass')
             mock_cp.assert_called_once_with(
                 path='hana.conf',
                 dest=hanamod.TMP_CONFIG_FILE)
             mock_update.assert_called_once_with(
                 conf_file=hanamod.TMP_CONFIG_FILE,
-                extra_parameters={u'hostname': u'hana01'})
+                hostname='hana01')
             mock_install.assert_called_once_with(
                 software_path='/software',
                 conf_file='hana_updated.conf',
@@ -228,7 +229,7 @@ class HanamodTestCase(TestCase, LoaderModuleMockMixin):
                     root_user='root'),
                 mock.call(
                     conf_file='hana_updated.conf',
-                    extra_parameters={u'hostname': u'hana01'})
+                    hostname='hana01')
             ])
 
             mock_install.assert_called_once_with(


### PR DESCRIPTION
I have started testing the `xs` installation in our deployment, and I have found out that the `extra_parameters` variable is not working.
This patch fixes this issue.
Besides that, I have added the option to customize more passwords in the passwords xml file. All the passwords are now in a list. And if a new entry in `extra_parameters` matches, it will be included in the passwords instead of the standard configuration file.

@diegoakechi I don't know if we should open a bug in bugzilla to track this an create a new MU update. I don't thing it's critical anyway