### PR TITLE
Create cloud_grains_present state

### DIFF
--- a/salt-shaptools.changes
+++ b/salt-shaptools.changes
@@ -1,4 +1,9 @@
 -------------------------------------------------------------------
+Fri Sep 11 14:09:09 UTC 2020 - Xabier Arbulu <xarbulu@suse.com>
+
+- Add cloud_grains_present state
+
+-------------------------------------------------------------------
 Tue Jun  9 13:08:47 UTC 2020 - Xabier Arbulu <xarbulu@suse.com>
 
 - Version 0.3.9

--- a/salt/states/crmshmod.py
+++ b/salt/states/crmshmod.py
@@ -548,3 +548,50 @@ def cluster_op_defaults_present(
     ret['comment'] = 'Cluster op_defaults configured'
     ret['result'] = True
     return ret
+
+
+def cloud_grains_present(
+        name):
+    """
+    Set the required cloud providers data in the grains
+
+    All providers: cloud_provider
+    Only gcp: gcp_instance_id, gcp_instance_name
+
+    name:
+        This parameter is ignored
+    """
+
+    changes = {}
+    ret = {'name': name,
+           'changes': changes,
+           'result': False,
+           'comment': ''}
+
+    if __opts__['test']:
+        ret['result'] = None
+        ret['comment'] = 'Cloud grains would be set'
+        ret['changes'] = changes
+        return ret
+
+    cloud_provider = __salt__['crm.detect_cloud']()
+    __salt__['grains.set']('cloud_provider', cloud_provider)
+    changes['cloud_provider'] = cloud_provider
+
+    if cloud_provider == 'google-cloud-platform':
+        gcp_instance_id = __salt__['http.query'](
+            url='http://metadata.google.internal/computeMetadata/v1/instance/id',
+            header_dict={"Metadata-Flavor": "Google"})['body']
+        __salt__['grains.set']('gcp_instance_id', gcp_instance_id)
+        changes['gcp_instance_id'] = gcp_instance_id
+
+        gcp_instance_name = __salt__['http.query'](
+            url='http://metadata.google.internal/computeMetadata/v1/instance/name',
+            header_dict={"Metadata-Flavor": "Google"})['body']
+        __salt__['grains.set']('gcp_instance_name', gcp_instance_name)
+        changes['gcp_instance_name'] = gcp_instance_name
+
+    ret['changes'] = changes
+    ret['comment'] = 'Cloud grains set'
+    ret['result'] = True
+    return ret

--- a/salt/states/crmshmod.py
+++ b/salt/states/crmshmod.py
@@ -553,7 +553,12 @@ def cluster_op_defaults_present(
 def cloud_grains_present(
         name):
     """
-    Set the required cloud providers data in the grains
+    Set the required cloud providers data in the grains.
+
+    These grains are used by the `habootstrap-formula` to identify if the current
+    execution is being done in the cloud, and if this is the case, set the information
+    regarding the current cloud provider that is used later to run certain states and
+    populate the configuration templates.
 
     All providers: cloud_provider
     Only gcp: gcp_instance_id, gcp_instance_name


### PR DESCRIPTION
New salt state for https://github.com/SUSE/habootstrap-formula/pull/58

It basically assigns the required cloud information to grains to be used later. This is the unique way to use runtime variables in salt in the same execution.

Fix for: https://github.com/SUSE/habootstrap-formula/issues/57