### PR TITLE
Feature/ensa grains present

### DIFF
--- a/salt-shaptools.changes
+++ b/salt-shaptools.changes
@@ -1,4 +1,9 @@
 -------------------------------------------------------------------
+Thu Sep 24 12:42:59 UTC 2020 - Xabier Arbulu <xarbulu@suse.com>
+
+- Implement a new state to set the ENSA version grains data 
+
+-------------------------------------------------------------------
 Fri Sep 11 14:09:09 UTC 2020 - Xabier Arbulu <xarbulu@suse.com>
 
 - Version 0.3.10

--- a/salt/modules/netweavermod.py
+++ b/salt/modules/netweavermod.py
@@ -382,6 +382,30 @@ def install_ers(
         raise exceptions.CommandExecutionError(err)
 
 
+def get_ensa_version(
+        sap_instance,
+        sid=None,
+        inst=None,
+        password=None):
+    '''
+    Get currently installed sap instance ENSA version
+
+    sap_instance
+        Check for specific SAP instances. Available options: ascs, ers.
+    sid
+        Netweaver system id (PRD for example)
+    inst
+        Netweaver instance number (00 for example)
+    password
+        Netweaver instance password
+    '''
+    try:
+        netweaver_inst = _init(sid, inst, password)
+        return netweaver_inst.get_ensa_version(sap_instance)
+    except ValueError as err:
+        raise exceptions.CommandExecutionError(err)
+
+
 def setup_cwd(
         software_path,
         cwd='/tmp/swpm_unattended',

--- a/salt/modules/netweavermod.py
+++ b/salt/modules/netweavermod.py
@@ -402,7 +402,7 @@ def get_ensa_version(
     try:
         netweaver_inst = _init(sid, inst, password)
         return netweaver_inst.get_ensa_version(sap_instance)
-    except ValueError as err:
+    except (ValueError, netweaver.NetweaverError) as err:
         raise exceptions.CommandExecutionError(err)
 
 

--- a/salt/states/netweavermod.py
+++ b/salt/states/netweavermod.py
@@ -490,8 +490,12 @@ def ensa_version_grains_present(
         ret['changes'] = changes
         return ret
 
-    ensa_version = __salt__['netweaver.get_ensa_version'](
-        sap_instance, sid, inst, password)
+    try:
+        ensa_version = __salt__['netweaver.get_ensa_version'](
+            sap_instance, sid, inst, password)
+    except exceptions.CommandExecutionError as err:
+        ret['comment'] = six.text_type(err)
+        return ret
 
     __salt__['grains.set']('ensa_version', ensa_version)
     changes['ensa_version'] = ensa_version

--- a/salt/states/netweavermod.py
+++ b/salt/states/netweavermod.py
@@ -464,7 +464,7 @@ def ensa_version_grains_present(
         inst=None,
         password=None):
     '''
-    Set the `ensa_version` grain with the currently installed ENSA version
+    Set the `ensa_version_{sid}_{inst}` grain with the currently installed ENSA version
 
     name (sap_instance)
         Check for specific SAP instances. Available options: ascs, ers.
@@ -497,8 +497,9 @@ def ensa_version_grains_present(
         ret['comment'] = six.text_type(err)
         return ret
 
-    __salt__['grains.set']('ensa_version', ensa_version)
-    changes['ensa_version'] = ensa_version
+    grain_key = 'ensa_version_{}_{}'.format(sid, inst)
+    __salt__['grains.set'](grain_key, ensa_version)
+    changes[grain_key] = ensa_version
 
     ret['changes'] = changes
     ret['comment'] = 'ENSA version grain set'

--- a/salt/states/netweavermod.py
+++ b/salt/states/netweavermod.py
@@ -456,3 +456,47 @@ def sapservices_updated(
     except exceptions.CommandExecutionError as err:
         ret['comment'] = six.text_type(err)
         return ret
+
+
+def ensa_version_grains_present(
+        name,
+        sid=None,
+        inst=None,
+        password=None):
+    '''
+    Set the `ensa_version` grain with the currently installed ENSA version
+
+    name (sap_instance)
+        Check for specific SAP instances. Available options: ascs, ers.
+    sid
+        Netweaver system id (PRD for example)
+    inst
+        Netweaver instance number (00 for example)
+    password
+        Netweaver instance password
+    '''
+
+    sap_instance = name
+
+    changes = {}
+    ret = {'name': name,
+           'changes': changes,
+           'result': False,
+           'comment': ''}
+
+    if __opts__['test']:
+        ret['result'] = None
+        ret['comment'] = 'ENSA version grain would be set'
+        ret['changes'] = changes
+        return ret
+
+    ensa_version = __salt__['netweaver.get_ensa_version'](
+        sap_instance, sid, inst, password)
+
+    __salt__['grains.set']('ensa_version', ensa_version)
+    changes['ensa_version'] = ensa_version
+
+    ret['changes'] = changes
+    ret['comment'] = 'ENSA version grain set'
+    ret['result'] = True
+    return ret

--- a/salt/states/netweavermod.py
+++ b/salt/states/netweavermod.py
@@ -477,6 +477,7 @@ def ensa_version_grains_present(
     '''
 
     sap_instance = name
+    inst = '{:0>2}'.format(inst)
 
     changes = {}
     ret = {'name': name,

--- a/tests/unit/modules/test_netweavermod.py
+++ b/tests/unit/modules/test_netweavermod.py
@@ -386,6 +386,35 @@ class NetweaverModuleTest(TestCase, LoaderModuleMockMixin):
             'root', 'root', ascs_password=None, timeout=0, interval=5, cwd=None)
         assert 'netweaver error' in str(err.value)
 
+    @patch('salt.modules.netweavermod.netweaver.NetweaverInstance')
+    def test_get_ensa_version(self, mock_netweaver):
+        '''
+        Test install method - raise
+        '''
+        mock_netweaver_instance = mock.Mock()
+        mock_netweaver_instance.get_ensa_version.return_value = 1
+        mock_netweaver.return_value = mock_netweaver_instance
+        with patch.object(netweavermod, '_init', mock_netweaver):
+            version = netweavermod.get_ensa_version('ascs', 'prd', '00', 'pass')
+            assert version == 1
+        mock_netweaver.assert_called_once_with('prd', '00', 'pass')
+        mock_netweaver_instance.get_ensa_version.assert_called_once_with('ascs')
+
+    @patch('salt.modules.netweavermod.netweaver.NetweaverInstance')
+    def test_get_ensa_version_error(self, mock_netweaver):
+        '''
+        Test install method - raise
+        '''
+        mock_netweaver_instance = mock.Mock()
+        mock_netweaver_instance.get_ensa_version.side_effect = ValueError('invalid instance')
+        mock_netweaver.return_value = mock_netweaver_instance
+        with patch.object(netweavermod, '_init', mock_netweaver):
+            with pytest.raises(exceptions.CommandExecutionError) as err:
+                netweavermod.get_ensa_version('ascs', 'prd', '00', 'pass')
+            assert'invalid instance' in str(err.value)
+        mock_netweaver.assert_called_once_with('prd', '00', 'pass')
+        mock_netweaver_instance.get_ensa_version.assert_called_once_with('ascs')
+
     def test_setup_cwd(self):
 
         mock_remove = mock.MagicMock()

--- a/tests/unit/modules/test_netweavermod.py
+++ b/tests/unit/modules/test_netweavermod.py
@@ -410,8 +410,20 @@ class NetweaverModuleTest(TestCase, LoaderModuleMockMixin):
         mock_netweaver.return_value = mock_netweaver_instance
         with patch.object(netweavermod, '_init', mock_netweaver):
             with pytest.raises(exceptions.CommandExecutionError) as err:
-                netweavermod.get_ensa_version('ascs', 'prd', '00', 'pass')
+                netweavermod.get_ensa_version('other', 'prd', '00', 'pass')
             assert'invalid instance' in str(err.value)
+        mock_netweaver.assert_called_once_with('prd', '00', 'pass')
+        mock_netweaver_instance.get_ensa_version.assert_called_once_with('other')
+
+        mock_netweaver.reset_mock()
+        mock_netweaver_instance.reset_mock()
+        mock_netweaver_instance.get_ensa_version.side_effect = \
+            netweavermod.netweaver.NetweaverError('Netweaver error')
+        mock_netweaver.return_value = mock_netweaver_instance
+        with patch.object(netweavermod, '_init', mock_netweaver):
+            with pytest.raises(exceptions.CommandExecutionError) as err:
+                netweavermod.get_ensa_version('ascs', 'prd', '00', 'pass')
+            assert'Netweaver error' in str(err.value)
         mock_netweaver.assert_called_once_with('prd', '00', 'pass')
         mock_netweaver_instance.get_ensa_version.assert_called_once_with('ascs')
 

--- a/tests/unit/states/test_netweavermod.py
+++ b/tests/unit/states/test_netweavermod.py
@@ -674,3 +674,12 @@ class NetweavermodTestCase(TestCase, LoaderModuleMockMixin):
             assert netweavermod.ensa_version_grains_present(
                 'ascs', 'prd', '00', 'pass') == ret
         mock_grains_set.assert_called_once_with('ensa_version_prd_00', 1)
+
+        mock_grains_set.reset_mock()
+
+        with patch.dict(netweavermod.__salt__, {
+                'netweaver.get_ensa_version': mock_get_ensa_version,
+                'grains.set': mock_grains_set}):
+            assert netweavermod.ensa_version_grains_present(
+                'ascs', 'prd', 0, 'pass') == ret
+        mock_grains_set.assert_called_once_with('ensa_version_prd_00', 1)

--- a/tests/unit/states/test_netweavermod.py
+++ b/tests/unit/states/test_netweavermod.py
@@ -661,7 +661,7 @@ class NetweavermodTestCase(TestCase, LoaderModuleMockMixin):
         '''
 
         ret = {'name': 'ascs',
-               'changes': {'ensa_version': 1},
+               'changes': {'ensa_version_prd_00': 1},
                'result': True,
                'comment': 'ENSA version grain set'}
 
@@ -672,5 +672,5 @@ class NetweavermodTestCase(TestCase, LoaderModuleMockMixin):
                 'netweaver.get_ensa_version': mock_get_ensa_version,
                 'grains.set': mock_grains_set}):
             assert netweavermod.ensa_version_grains_present(
-                'ascs', 'prd', 00, 'pass') == ret
-        mock_grains_set.assert_called_once_with('ensa_version', 1)
+                'ascs', 'prd', '00', 'pass') == ret
+        mock_grains_set.assert_called_once_with('ensa_version_prd_00', 1)


### PR DESCRIPTION
Implement a new state to store the currently installed ENSA version. Thje new state sets the `ensa_version` grain with after being executed.
This state will be used in `sapnwbootstrap-formula`

Based on:
https://github.com/SUSE/shaptools/pull/59

More information in:
https://www.suse.com/c/suse-ha-sap-certified/
https://docs.microsoft.com/en-us/azure/virtual-machines/workloads/sap/high-availability-guide-suse#2d6008b0-685d-426c-b59e-6cd281fd45d7
https://launchpad.support.sap.com/#/notes/1410736

FYI @petersatsuse