### PR TITLE
Hotfix/improve extract pydbapi

### DIFF
--- a/salt-shaptools.changes
+++ b/salt-shaptools.changes
@@ -1,4 +1,9 @@
 -------------------------------------------------------------------
+Thu Oct 15 07:14:20 UTC 2020 - Xabier Arbulu <xarbulu@suse.com>
+
+- Improve extract_pydbapi to check recursively in subfolders 
+
+-------------------------------------------------------------------
 Thu Sep 24 12:42:59 UTC 2020 - Xabier Arbulu <xarbulu@suse.com>
 
 - Implement a new state to set the ENSA version grains data 

--- a/salt/modules/hanamod.py
+++ b/salt/modules/hanamod.py
@@ -27,6 +27,7 @@ import logging
 import time
 import re
 import sys
+import os
 
 if sys.version_info.major == 2: # pragma: no cover
     import imp
@@ -959,9 +960,17 @@ def reload_hdb_connector():  # pragma: no cover
     reload_module(hdb_connector)
 
 
-def _find_sap_folder(software_folders, folder_pattern):
+def _find_sap_folder(software_folders, folder_pattern, check_subfolder_level=0):
     '''
     Find a SAP folder following a recursive approach using the LABEL and LABELIDX files
+
+    Args:
+        software_folder (list): List of subfolder where the SAP folder is looked for`
+        folder_pattern (str): Pattern of the LABEL.ASC to look fo
+        check_subfolder_level (int): Number of subfolder levers to check.
+            Examples:
+                1 means to check recursively in the subfolder present in sofware_folder folders
+                2 measn to check in the first subfolder and the folder within
     '''
     for folder in software_folders:
         label = '{}/{}'.format(folder, LABEL_FILE)
@@ -988,6 +997,12 @@ def _find_sap_folder(software_folders, folder_pattern):
                     continue
         except IOError:
             LOGGER.debug('%s file not found in %s. Skipping folder', LABELIDX_FILE, folder)
+
+        if check_subfolder_level:
+            subfolders = [os.path.join(folder, found_dir) for found_dir in
+                          os.listdir(folder) if os.path.isdir(os.path.join(folder, found_dir))]
+
+            return _find_sap_folder(subfolders, folder_pattern, check_subfolder_level-1)
 
     raise SapFolderNotFoundError(
         'SAP folder with {} pattern not found'.format(folder_pattern.pattern))
@@ -1023,7 +1038,10 @@ def extract_pydbapi(
     hana_client_pattern = re.compile('^HDB_CLIENT:{}.*:{}:.*'.format(
         hana_version, current_platform))
     try:
-        hana_client_folder = _find_sap_folder(software_folders, hana_client_pattern)
+        # check_subfolder_level is set to 1 because the HANA client
+        # is extracted in SAP_HANA_CLIENT if the file is compressed as SAR
+        hana_client_folder = _find_sap_folder(
+            software_folders, hana_client_pattern, check_subfolder_level=1)
     except SapFolderNotFoundError:
         raise exceptions.CommandExecutionError('HANA client not found')
     pydbapi_file = '{}/client/{}'.format(hana_client_folder, name)

--- a/salt/modules/hanamod.py
+++ b/salt/modules/hanamod.py
@@ -1001,8 +1001,10 @@ def _find_sap_folder(software_folders, folder_pattern, check_subfolder_level=0):
         if check_subfolder_level:
             subfolders = [os.path.join(folder, found_dir) for found_dir in
                           os.listdir(folder) if os.path.isdir(os.path.join(folder, found_dir))]
-
-            return _find_sap_folder(subfolders, folder_pattern, check_subfolder_level-1)
+            try:
+                return _find_sap_folder(subfolders, folder_pattern, check_subfolder_level-1)
+            except SapFolderNotFoundError:
+                continue
 
     raise SapFolderNotFoundError(
         'SAP folder with {} pattern not found'.format(folder_pattern.pattern))

--- a/tests/unit/modules/test_crmshmod.py
+++ b/tests/unit/modules/test_crmshmod.py
@@ -16,16 +16,13 @@ from tests.support.unit import TestCase, skipIf
 from tests.support import mock
 from tests.support.mock import (
     MagicMock,
-    patch,
-    NO_MOCK,
-    NO_MOCK_REASON
+    patch
 )
 
 # Import Salt Libs
 import salt.modules.crmshmod as crmshmod
 
 
-@skipIf(NO_MOCK, NO_MOCK_REASON)
 class CrmshModuleTest(TestCase, LoaderModuleMockMixin):
     '''
     This class contains a set of functions that test salt.modules.crm.

--- a/tests/unit/modules/test_drbdmod.py
+++ b/tests/unit/modules/test_drbdmod.py
@@ -14,16 +14,13 @@ from tests.support.mixins import LoaderModuleMockMixin
 from tests.support.unit import TestCase, skipIf
 from tests.support.mock import (
     MagicMock,
-    patch,
-    NO_MOCK,
-    NO_MOCK_REASON
+    patch
 )
 
 # Import Salt Libs
 import salt.modules.drbdmod as drbd
 
 
-@skipIf(NO_MOCK, NO_MOCK_REASON)
 class DrbdTestCase(TestCase, LoaderModuleMockMixin):
     '''
     Test cases for salt.modules.drbd

--- a/tests/unit/modules/test_hanamod.py
+++ b/tests/unit/modules/test_hanamod.py
@@ -884,8 +884,8 @@ class HanaModuleTest(TestCase, LoaderModuleMockMixin):
     def test_find_sap_folder_contain_units(self, mock_debug):
         mock_pattern = mock.Mock(pattern='my_pattern')
         mock_pattern.match.side_effect = [False, True]
-        with patch('salt.utils.files.fopen', mock_open(read_data=
-                ['data\n', 'DATA_UNITS\n', 'data_2\n'])) as mock_file:
+        with patch('salt.utils.files.fopen', mock_open(read_data=[
+                'data\n', 'DATA_UNITS\n', 'data_2\n'])) as mock_file:
             folder = hanamod._find_sap_folder(['1234', '5678'], mock_pattern)
 
         mock_pattern.match.assert_has_calls([
@@ -898,13 +898,73 @@ class HanaModuleTest(TestCase, LoaderModuleMockMixin):
         assert folder in '1234/DATA_UNITS'
 
     @mock.patch('logging.Logger.debug')
+    @mock.patch('os.path.isdir')
+    @mock.patch('os.listdir')
+    def test_find_sap_folder_contain_subfolder(
+            self, mock_listdir, mock_isdir, mock_debug):
+        mock_pattern = mock.Mock(pattern='my_pattern')
+        mock_pattern.match.side_effect = [True]
+        mock_listdir.return_value = ['folder1', 'folder2', 'file1']
+        mock_isdir.side_effect = [True, True, False]
+
+        with patch('salt.utils.files.fopen', mock_open(
+                read_data=[IOError, IOError, 'subfolder\n'])) as mock_file:
+            with patch('salt.modules.hanamod._find_sap_folder',
+                       side_effect=hanamod._find_sap_folder) as mock_find_sap_folder:
+                folder = mock_find_sap_folder(['1234', '5678'], mock_pattern, 2)
+
+                mock_find_sap_folder.assert_has_calls([
+                    mock.call(['1234', '5678'], mock_pattern, 2),
+                    mock.call(['1234/folder1', '1234/folder2'], mock_pattern, 1)
+                ])
+
+        mock_listdir.assert_called_once_with('1234')
+
+        mock_isdir.assert_has_calls([
+            mock.call('1234/folder1'),
+            mock.call('1234/folder2'),
+            mock.call('1234/file1')
+        ])
+
+        assert folder == '1234/folder1'
+
+    @mock.patch('logging.Logger.debug')
+    @mock.patch('os.path.isdir')
+    @mock.patch('os.listdir')
+    def test_find_sap_folder_contain_subfolder_error(
+            self, mock_listdir, mock_isdir, mock_debug):
+        mock_pattern = mock.Mock(pattern='my_pattern')
+        mock_listdir.return_value = ['folder1', 'file1', 'file2']
+        mock_isdir.side_effect = [True, False, False]
+
+        with patch('salt.utils.files.fopen', mock_open(
+                read_data=[IOError, IOError, IOError, IOError])) as mock_file:
+            with patch('salt.modules.hanamod._find_sap_folder',
+                       side_effect=hanamod._find_sap_folder) as mock_find_sap_folder:
+                with pytest.raises(hanamod.SapFolderNotFoundError) as err:
+                    mock_find_sap_folder(['1234'], mock_pattern, 1)
+
+                mock_find_sap_folder.assert_has_calls([
+                    mock.call(['1234'], mock_pattern, 1),
+                    mock.call(['1234/folder1'], mock_pattern, 0)
+                ])
+
+        mock_listdir.assert_called_once_with('1234')
+
+        mock_isdir.assert_has_calls([
+            mock.call('1234/folder1'),
+            mock.call('1234/file1'),
+            mock.call('1234/file2')
+        ])
+
+    @mock.patch('logging.Logger.debug')
     def test_find_sap_folder_contain_units_error(self, mock_debug):
         mock_pattern = mock.Mock(pattern='my_pattern')
         mock_pattern.match.side_effect = [False, False]
         with patch('salt.utils.files.fopen', mock_open(read_data=[
                 'data\n', 'DATA_UNITS\n', 'data_2\n', IOError])) as mock_file:
             with pytest.raises(hanamod.SapFolderNotFoundError) as err:
-                folder = hanamod._find_sap_folder(['1234'], mock_pattern)
+                hanamod._find_sap_folder(['1234'], mock_pattern)
 
         mock_pattern.match.assert_has_calls([
             mock.call('data'),

--- a/tests/unit/modules/test_hanamod.py
+++ b/tests/unit/modules/test_hanamod.py
@@ -18,16 +18,13 @@ from tests.support import mock
 from tests.support.mock import (
     MagicMock,
     patch,
-    mock_open,
-    NO_MOCK,
-    NO_MOCK_REASON
+    mock_open
 )
 
 # Import Salt Libs
 import salt.modules.hanamod as hanamod
 
 
-@skipIf(NO_MOCK, NO_MOCK_REASON)
 class HanaModuleTest(TestCase, LoaderModuleMockMixin):
     '''
     This class contains a set of functions that test salt.modules.hana.

--- a/tests/unit/modules/test_hanamod.py
+++ b/tests/unit/modules/test_hanamod.py
@@ -990,7 +990,7 @@ class HanaModuleTest(TestCase, LoaderModuleMockMixin):
 
         mock_compile.assert_called_once_with('^HDB_CLIENT:20.*:LINUX_X86_64:.*')
         mock_find_sap_folders.assert_called_once_with(
-            ['1234', '5678'], compile_mocked, check_subfolder_level=1)
+            ['1234', '5678'], compile_mocked, recursion_level=1)
         mock_tar.assert_called_once_with(
             options='-l -xvf', tarfile='my_folder/client/PYDBAPI.tar.gz', cwd='/tmp/output')
         assert pydbapi_file == 'my_folder/client/PYDBAPI.tar.gz'
@@ -1009,7 +1009,7 @@ class HanaModuleTest(TestCase, LoaderModuleMockMixin):
 
         mock_compile.assert_called_once_with('^HDB_CLIENT:20.*:LINUX_X86_64:.*')
         mock_find_sap_folders.assert_called_once_with(
-            ['1234', '5678'], compile_mocked, check_subfolder_level=1)
+            ['1234', '5678'], compile_mocked, recursion_level=1)
         assert 'HANA client not found' in str(err.value)
 
     def test_extract_pydbapi_software_folders_type_error(self):

--- a/tests/unit/modules/test_hanamod.py
+++ b/tests/unit/modules/test_hanamod.py
@@ -933,7 +933,7 @@ class HanaModuleTest(TestCase, LoaderModuleMockMixin):
 
         mock_compile.assert_called_once_with('^HDB_CLIENT:20.*:LINUX_X86_64:.*')
         mock_find_sap_folders.assert_called_once_with(
-            ['1234', '5678'], compile_mocked)
+            ['1234', '5678'], compile_mocked, check_subfolder_level=1)
         mock_tar.assert_called_once_with(
             options='-l -xvf', tarfile='my_folder/client/PYDBAPI.tar.gz', cwd='/tmp/output')
         assert pydbapi_file == 'my_folder/client/PYDBAPI.tar.gz'
@@ -952,7 +952,7 @@ class HanaModuleTest(TestCase, LoaderModuleMockMixin):
 
         mock_compile.assert_called_once_with('^HDB_CLIENT:20.*:LINUX_X86_64:.*')
         mock_find_sap_folders.assert_called_once_with(
-            ['1234', '5678'], compile_mocked)
+            ['1234', '5678'], compile_mocked, check_subfolder_level=1)
         assert 'HANA client not found' in str(err.value)
 
     def test_extract_pydbapi_software_folders_type_error(self):

--- a/tests/unit/modules/test_netweavermod.py
+++ b/tests/unit/modules/test_netweavermod.py
@@ -15,16 +15,13 @@ from tests.support.unit import TestCase, skipIf
 from tests.support import mock
 from tests.support.mock import (
     MagicMock,
-    patch,
-    NO_MOCK,
-    NO_MOCK_REASON
+    patch
 )
 
 # Import Salt Libs
 import salt.modules.netweavermod as netweavermod
 
 
-@skipIf(NO_MOCK, NO_MOCK_REASON)
 class NetweaverModuleTest(TestCase, LoaderModuleMockMixin):
     '''
     This class contains a set of functions that test salt.modules.netweavermod.

--- a/tests/unit/modules/test_sapcarmod.py
+++ b/tests/unit/modules/test_sapcarmod.py
@@ -17,16 +17,13 @@ from tests.support import mock
 from tests.support.mock import (
     MagicMock,
     patch,
-    mock_open,
-    NO_MOCK,
-    NO_MOCK_REASON
+    mock_open
 )
 
 # Import Salt Libs
 import salt.modules.sapcarmod as sapcarmod
 
 
-@skipIf(NO_MOCK, NO_MOCK_REASON)
 class SapcarModuleTest(TestCase, LoaderModuleMockMixin):
     '''
     This class contains a set of functions that test salt.modules.sapcarmod.
@@ -57,4 +54,3 @@ class SapcarModuleTest(TestCase, LoaderModuleMockMixin):
         mock_extract.assert_called_once_with(
             sapcar_exe='/sapmedia/SAPCAR', sar_file='/sapmedia/IMDB_SERVER_LINUX.SAR',
             output_dir='/sapmedia/HANA', options='-v')
-        

--- a/tests/unit/modules/test_saptunemod.py
+++ b/tests/unit/modules/test_saptunemod.py
@@ -14,16 +14,13 @@ from tests.support import mock
 from tests.support.mock import (
     MagicMock,
     patch,
-    mock_open,
-    NO_MOCK,
-    NO_MOCK_REASON
+    mock_open
 )
 
 # Import Salt Libs
 import salt.modules.saptunemod as saptune
 
 
-@skipIf(NO_MOCK, NO_MOCK_REASON)
 class SaptuneModuleTest(TestCase, LoaderModuleMockMixin):
     '''
     This class contains a set of functions that test salt.modules.saptune.

--- a/tests/unit/states/test_crmshmod.py
+++ b/tests/unit/states/test_crmshmod.py
@@ -15,8 +15,6 @@ from tests.support.mixins import LoaderModuleMockMixin
 from tests.support.unit import skipIf, TestCase
 from tests.support import mock
 from tests.support.mock import (
-    NO_MOCK,
-    NO_MOCK_REASON,
     mock_open,
     MagicMock,
     patch
@@ -26,7 +24,6 @@ from tests.support.mock import (
 import salt.states.crmshmod as crmshmod
 
 
-@skipIf(NO_MOCK, NO_MOCK_REASON)
 class CrmshmodTestCase(TestCase, LoaderModuleMockMixin):
     '''
     Test cases for salt.states.crm

--- a/tests/unit/states/test_drbdmod.py
+++ b/tests/unit/states/test_drbdmod.py
@@ -13,9 +13,7 @@ from tests.support.mixins import LoaderModuleMockMixin
 from tests.support.unit import TestCase, skipIf
 from tests.support.mock import (
     MagicMock,
-    patch,
-    NO_MOCK,
-    NO_MOCK_REASON
+    patch
 )
 
 # Import Salt Libs
@@ -25,7 +23,6 @@ import time
 RES_NAME = 'dummy'
 
 
-@skipIf(NO_MOCK, NO_MOCK_REASON)
 class DrbdStatesTestCase(TestCase, LoaderModuleMockMixin):
     '''
     Test cases for salt.states.drbd

--- a/tests/unit/states/test_hanamod.py
+++ b/tests/unit/states/test_hanamod.py
@@ -13,8 +13,6 @@ from tests.support.mixins import LoaderModuleMockMixin
 from tests.support.unit import skipIf, TestCase
 from tests.support import mock
 from tests.support.mock import (
-    NO_MOCK,
-    NO_MOCK_REASON,
     MagicMock,
     patch
 )
@@ -23,7 +21,6 @@ from tests.support.mock import (
 import salt.states.hanamod as hanamod
 
 
-@skipIf(NO_MOCK, NO_MOCK_REASON)
 class HanamodTestCase(TestCase, LoaderModuleMockMixin):
     '''
     Test cases for salt.states.hanamod

--- a/tests/unit/states/test_netweavermod.py
+++ b/tests/unit/states/test_netweavermod.py
@@ -13,8 +13,6 @@ from tests.support.mixins import LoaderModuleMockMixin
 from tests.support.unit import skipIf, TestCase
 from tests.support import mock
 from tests.support.mock import (
-    NO_MOCK,
-    NO_MOCK_REASON,
     MagicMock,
     patch
 )
@@ -23,7 +21,6 @@ from tests.support.mock import (
 import salt.states.netweavermod as netweavermod
 
 
-@skipIf(NO_MOCK, NO_MOCK_REASON)
 class NetweavermodTestCase(TestCase, LoaderModuleMockMixin):
     '''
     Test cases for salt.states.netweavermod

--- a/tests/unit/states/test_sapcarmod.py
+++ b/tests/unit/states/test_sapcarmod.py
@@ -13,8 +13,6 @@ from tests.support.mixins import LoaderModuleMockMixin
 from tests.support.unit import skipIf, TestCase
 from tests.support import mock
 from tests.support.mock import (
-    NO_MOCK,
-    NO_MOCK_REASON,
     MagicMock,
     patch
 )
@@ -23,7 +21,6 @@ from tests.support.mock import (
 import salt.states.sapcarmod as sapcar
 
 
-@skipIf(NO_MOCK, NO_MOCK_REASON)
 class SapcarmodTestCase(TestCase, LoaderModuleMockMixin):
     '''
     Test cases for salt.states.sapcarmod

--- a/tests/unit/states/test_saptunemod.py
+++ b/tests/unit/states/test_saptunemod.py
@@ -13,8 +13,6 @@ from tests.support.mixins import LoaderModuleMockMixin
 from tests.support.unit import skipIf, TestCase
 from tests.support import mock
 from tests.support.mock import (
-    NO_MOCK,
-    NO_MOCK_REASON,
     MagicMock,
     patch
 )
@@ -23,7 +21,6 @@ from tests.support.mock import (
 import salt.states.saptunemod as saptune
 
 
-@skipIf(NO_MOCK, NO_MOCK_REASON)
 class SaptunemodTestCase(TestCase, LoaderModuleMockMixin):
     '''
     Test cases for salt.states.saptunemod


### PR DESCRIPTION
Implement the improvement of `extract_dbapi` to check recursively in subfolders. This is needed in order to find the `PYDBAPI.TGZ` file in a SAP HANA client folder, if this is extracted from a `SAR` file.

This folder is extracted putting the HANA client in `IMDB_CLIENT20_004_182-80002082/SAP_HANA_CLIENT` kind of folder, so if we check directly in the 1st one, the file is not there, so we need to check in the child subfolder.

Besides that, many imported packages for Unit tests have been removed, as they are not shipped anymore in Salt 3000 version (`NO_MOCK` and `NO_MOCK_REASON`)