### PR TITLE
Remove --no-overwrite-sshkey: the option is deprecated

### DIFF
--- a/salt-shaptools.changes
+++ b/salt-shaptools.changes
@@ -1,4 +1,9 @@
 -------------------------------------------------------------------
+Wed Dec 16 09:04:29 UTC 2020 - Aleksei Burlakov <aburlakov@suse.com>
+
+- qdevice support: it can be created when initializing a cluster
+
+-------------------------------------------------------------------
 Thu Oct 15 07:14:20 UTC 2020 - Xabier Arbulu <xarbulu@suse.com>
 
 - Version 0.3.11

--- a/salt-shaptools.changes
+++ b/salt-shaptools.changes
@@ -1,4 +1,9 @@
 -------------------------------------------------------------------
+Wed Dec 16 11:30:22 UTC 2020 - Aleksei Burlakov <aburlakov@suse.com>
+
+- remove --no-overwrite-sshkey: the option is deprecated
+
+-------------------------------------------------------------------
 Wed Dec 16 09:04:29 UTC 2020 - Aleksei Burlakov <aburlakov@suse.com>
 
 - qdevice support: it can be created when initializing a cluster

--- a/salt/modules/crmshmod.py
+++ b/salt/modules/crmshmod.py
@@ -290,6 +290,7 @@ def _crm_init(
         sbd=None,
         sbd_dev=None,
         no_overwrite_sshkey=False,
+        qnetd_hostname=None,
         quiet=None):
     '''
     crm cluster init command execution
@@ -311,6 +312,9 @@ def _crm_init(
         cmd = '{cmd} -S'.format(cmd=cmd)
     if no_overwrite_sshkey:
         cmd = '{cmd} --no-overwrite-sshkey'.format(cmd=cmd)
+    if qnetd_hostname:
+        cmd = '{cmd} --qnetd-hostname {qnetd_hostname}'.format(
+            cmd=cmd, qnetd_hostname=qnetd_hostname)
     if quiet:
         cmd = '{cmd} -q'.format(cmd=cmd)
 
@@ -324,6 +328,7 @@ def _ha_cluster_init(
         admin_ip=None,
         sbd=None,
         sbd_dev=None,
+        qnetd_hostname=None,
         quiet=None):
     '''
     ha-cluster-init command execution
@@ -342,6 +347,9 @@ def _ha_cluster_init(
         cmd = '{cmd} {sbd_str}'.format(cmd=cmd, sbd_str=sbd_str)
     elif sbd:
         cmd = '{cmd} -S'.format(cmd=cmd)
+    if qnetd_hostname:
+        cmd = '{cmd} --qnetd-hostname {qnetd_hostname}'.format(
+            cmd=cmd, qnetd_hostname=qnetd_hostname)
     if quiet:
         cmd = '{cmd} -q'.format(cmd=cmd)
 
@@ -362,6 +370,7 @@ def cluster_init(
         sbd=None,
         sbd_dev=None,
         no_overwrite_sshkey=False,
+        qnetd_hostname=None,
         quiet=None):
     '''
     Initialize a cluster from scratch.
@@ -387,6 +396,8 @@ def cluster_init(
     no_overwrite_sshkey
         No overwrite the currently existing sshkey (/root/.ssh/id_rsa)
         Only available after crmsh 3.0.0
+    qnetd_hostname:
+        The name of the qnetd node. If none, no qdevice is created
     quiet:
         execute the command in quiet mode (no output)
 
@@ -403,13 +414,14 @@ def cluster_init(
     # and create the corresponing UT
     if __salt__['crm.use_crm']:
         return _crm_init(
-            name, watchdog, interface, unicast, admin_ip, sbd, sbd_dev, no_overwrite_sshkey, quiet)
+            name, watchdog, interface, unicast, admin_ip, sbd, sbd_dev, no_overwrite_sshkey,
+            qnetd_hostname, quiet)
 
     LOGGER.warning('The parameter name is not considered!')
     LOGGER.warning('--no_overwrite_sshkey option not available')
 
     return _ha_cluster_init(
-        watchdog, interface, unicast, admin_ip, sbd, sbd_dev, quiet)
+        watchdog, interface, unicast, admin_ip, sbd, sbd_dev, qnetd_hostname, quiet)
 
 
 def _crm_join(

--- a/salt/modules/crmshmod.py
+++ b/salt/modules/crmshmod.py
@@ -289,7 +289,6 @@ def _crm_init(
         admin_ip=None,
         sbd=None,
         sbd_dev=None,
-        no_overwrite_sshkey=False,
         qnetd_hostname=None,
         quiet=None):
     '''
@@ -310,8 +309,6 @@ def _crm_init(
         cmd = '{cmd} {sbd_str}'.format(cmd=cmd, sbd_str=sbd_str)
     elif sbd:
         cmd = '{cmd} -S'.format(cmd=cmd)
-    if no_overwrite_sshkey:
-        cmd = '{cmd} --no-overwrite-sshkey'.format(cmd=cmd)
     if qnetd_hostname:
         cmd = '{cmd} --qnetd-hostname {qnetd_hostname}'.format(
             cmd=cmd, qnetd_hostname=qnetd_hostname)
@@ -369,7 +366,6 @@ def cluster_init(
         admin_ip=None,
         sbd=None,
         sbd_dev=None,
-        no_overwrite_sshkey=False,
         qnetd_hostname=None,
         quiet=None):
     '''
@@ -393,9 +389,6 @@ def cluster_init(
     sbd_dev
         sbd device path
         This parameter can be a string (meaning one disk) or a list with multiple disks
-    no_overwrite_sshkey
-        No overwrite the currently existing sshkey (/root/.ssh/id_rsa)
-        Only available after crmsh 3.0.0
     qnetd_hostname:
         The name of the qnetd node. If none, no qdevice is created
     quiet:
@@ -414,11 +407,8 @@ def cluster_init(
     # and create the corresponing UT
     if __salt__['crm.use_crm']:
         return _crm_init(
-            name, watchdog, interface, unicast, admin_ip, sbd, sbd_dev, no_overwrite_sshkey,
+            name, watchdog, interface, unicast, admin_ip, sbd, sbd_dev,
             qnetd_hostname, quiet)
-
-    LOGGER.warning('The parameter name is not considered!')
-    LOGGER.warning('--no_overwrite_sshkey option not available')
 
     return _ha_cluster_init(
         watchdog, interface, unicast, admin_ip, sbd, sbd_dev, qnetd_hostname, quiet)

--- a/salt/states/crmshmod.py
+++ b/salt/states/crmshmod.py
@@ -106,7 +106,8 @@ def cluster_initialized(
         sbd=None,
         sbd_dev=None,
         no_overwrite_sshkey=False,
-        quiet=None):
+        quiet=None,
+        qnetd_hostname=None):
     """
     Machine is running a cluster node
 
@@ -131,6 +132,8 @@ def cluster_initialized(
         Only available after crmsh 3.0.0
     quiet:
         execute the command in quiet mode (no output)
+    qnetd_hostname:
+        The name of the qnetd node. If none, no qdevice is created
     """
     ret = {'name': name,
            'changes': {},
@@ -159,6 +162,7 @@ def cluster_initialized(
             sbd=sbd,
             sbd_dev=sbd_dev,
             no_overwrite_sshkey=no_overwrite_sshkey,
+            qnetd_hostname=qnetd_hostname,
             quiet=quiet)
 
         if result:

--- a/salt/states/crmshmod.py
+++ b/salt/states/crmshmod.py
@@ -105,7 +105,6 @@ def cluster_initialized(
         admin_ip=None,
         sbd=None,
         sbd_dev=None,
-        no_overwrite_sshkey=False,
         quiet=None,
         qnetd_hostname=None):
     """
@@ -127,9 +126,6 @@ def cluster_initialized(
     sbd_dev
         sbd device path
         This parameter can be a string (meaning one disk) or a list with multiple disks
-    no_overwrite_sshkey
-        No overwrite the currently existing sshkey (/root/.ssh/id_rsa)
-        Only available after crmsh 3.0.0
     quiet:
         execute the command in quiet mode (no output)
     qnetd_hostname:
@@ -161,7 +157,6 @@ def cluster_initialized(
             admin_ip=admin_ip,
             sbd=sbd,
             sbd_dev=sbd_dev,
-            no_overwrite_sshkey=no_overwrite_sshkey,
             qnetd_hostname=qnetd_hostname,
             quiet=quiet)
 

--- a/tests/unit/modules/test_crmshmod.py
+++ b/tests/unit/modules/test_crmshmod.py
@@ -349,22 +349,22 @@ class CrmshModuleTest(TestCase, LoaderModuleMockMixin):
 
         with patch.dict(crmshmod.__salt__, {'cmd.retcode': mock_cmd_run}):
             result = crmshmod._crm_init(
-                'hacluster', 'dog', 'eth1', True, '192.168.1.50', True, ['dev1', 'dev2'], True, 'alice', True)
+                'hacluster', 'dog', 'eth1', True, '192.168.1.50', True, ['dev1', 'dev2'], 'alice', True)
             assert result
             mock_cmd_run.assert_called_once_with(
                 '{} cluster init -y -n {} -w {} -i {} -u -A {} '
-                '-s {} -s {} --no-overwrite-sshkey --qnetd-hostname {} -q'.format(
+                '-s {} -s {} --qnetd-hostname {} -q'.format(
                     crmshmod.CRM_COMMAND, 'hacluster', 'dog', 'eth1', '192.168.1.50', 'dev1', 'dev2', 'alice'))
 
         # SBD diskless
         mock_cmd_run.reset_mock()
         with patch.dict(crmshmod.__salt__, {'cmd.retcode': mock_cmd_run}):
             result = crmshmod._crm_init(
-                'hacluster', 'dog', 'eth1', True, '192.168.1.50', True, None, True, 'alice', True)
+                'hacluster', 'dog', 'eth1', True, '192.168.1.50', True, None, 'alice', True)
             assert result
             mock_cmd_run.assert_called_once_with(
                 '{} cluster init -y -n {} -w {} -i {} -u -A {} '
-                '-S --no-overwrite-sshkey --qnetd-hostname {} -q'.format(
+                '-S --qnetd-hostname {} -q'.format(
                     crmshmod.CRM_COMMAND, 'hacluster', 'dog', 'eth1', '192.168.1.50', 'alice'))
 
     def test_ha_cluster_init_basic(self):
@@ -427,7 +427,7 @@ class CrmshModuleTest(TestCase, LoaderModuleMockMixin):
             value = crmshmod.cluster_init('hacluster', 'dog', 'eth1', sbd=True, sbd_dev='dev1')
             assert value == 0
             crm_init.assert_called_once_with(
-                'hacluster', 'dog', 'eth1', None, None, True, ['dev1'], False, None, None)
+                'hacluster', 'dog', 'eth1', None, None, True, ['dev1'], None, None)
 
         crm_init.reset_mock()
         with patch.dict(crmshmod.__salt__, {'crm.use_crm': True}):
@@ -435,7 +435,7 @@ class CrmshModuleTest(TestCase, LoaderModuleMockMixin):
             value = crmshmod.cluster_init('hacluster', 'dog', 'eth1', sbd=False, sbd_dev=['disk1', 'disk2'])
             assert value == 0
             crm_init.assert_called_once_with(
-                'hacluster', 'dog', 'eth1', None, None, False, ['disk1', 'disk2'], False, None, None)
+                'hacluster', 'dog', 'eth1', None, None, False, ['disk1', 'disk2'], None, None)
 
     @mock.patch('logging.Logger.warning')
     @mock.patch('salt.modules.crmshmod._ha_cluster_init')
@@ -447,12 +447,8 @@ class CrmshModuleTest(TestCase, LoaderModuleMockMixin):
         with patch.dict(crmshmod.__salt__, {'crm.use_crm': False}):
             ha_cluster_init.return_value = 0
             value = crmshmod.cluster_init(
-                'hacluster', 'dog', 'eth1', sbd_dev='dev1', no_overwrite_sshkey=True)
+                'hacluster', 'dog', 'eth1', sbd_dev='dev1')
             assert value == 0
-            logger.assert_has_calls([
-                mock.call('The parameter name is not considered!'),
-                mock.call('--no_overwrite_sshkey option not available')
-            ])
             ha_cluster_init.assert_called_once_with(
                 'dog', 'eth1', None, None, None, ['dev1'], None, None)
 

--- a/tests/unit/states/test_crmshmod.py
+++ b/tests/unit/states/test_crmshmod.py
@@ -189,6 +189,7 @@ class CrmshmodTestCase(TestCase, LoaderModuleMockMixin):
                 sbd=True,
                 sbd_dev='/dev/sbd',
                 no_overwrite_sshkey=True,
+                qnetd_hostname=None,
                 quiet=False)
 
     def test_initialized_error(self):
@@ -225,6 +226,7 @@ class CrmshmodTestCase(TestCase, LoaderModuleMockMixin):
                 sbd=True,
                 sbd_dev='/dev/sbd',
                 no_overwrite_sshkey=True,
+                qnetd_hostname=None,
                 quiet=False)
 
     def test_initialized_command_error(self):
@@ -262,6 +264,7 @@ class CrmshmodTestCase(TestCase, LoaderModuleMockMixin):
                 sbd=True,
                 sbd_dev='/dev/sbd',
                 no_overwrite_sshkey=False,
+                qnetd_hostname=None,
                 quiet=False)
 
     # 'joined' function tests

--- a/tests/unit/states/test_crmshmod.py
+++ b/tests/unit/states/test_crmshmod.py
@@ -177,7 +177,6 @@ class CrmshmodTestCase(TestCase, LoaderModuleMockMixin):
                 admin_ip='192.168.1.50',
                 sbd=True,
                 sbd_dev='/dev/sbd',
-                no_overwrite_sshkey=True,
                 quiet=False) == ret
             mock_status.assert_called_once_with()
             mock_init.assert_called_once_with(
@@ -188,7 +187,6 @@ class CrmshmodTestCase(TestCase, LoaderModuleMockMixin):
                 admin_ip='192.168.1.50',
                 sbd=True,
                 sbd_dev='/dev/sbd',
-                no_overwrite_sshkey=True,
                 qnetd_hostname=None,
                 quiet=False)
 
@@ -214,7 +212,6 @@ class CrmshmodTestCase(TestCase, LoaderModuleMockMixin):
                 admin_ip='192.168.1.50',
                 sbd=True,
                 sbd_dev='/dev/sbd',
-                no_overwrite_sshkey=True,
                 quiet=False) == ret
             mock_status.assert_called_once_with()
             mock_init.assert_called_once_with(
@@ -225,7 +222,6 @@ class CrmshmodTestCase(TestCase, LoaderModuleMockMixin):
                 admin_ip='192.168.1.50',
                 sbd=True,
                 sbd_dev='/dev/sbd',
-                no_overwrite_sshkey=True,
                 qnetd_hostname=None,
                 quiet=False)
 
@@ -252,7 +248,6 @@ class CrmshmodTestCase(TestCase, LoaderModuleMockMixin):
                 admin_ip='192.168.1.50',
                 sbd=True,
                 sbd_dev='/dev/sbd',
-                no_overwrite_sshkey=False,
                 quiet=False) == ret
             mock_status.assert_called_once_with()
             mock_init.assert_called_once_with(
@@ -263,7 +258,6 @@ class CrmshmodTestCase(TestCase, LoaderModuleMockMixin):
                 admin_ip='192.168.1.50',
                 sbd=True,
                 sbd_dev='/dev/sbd',
-                no_overwrite_sshkey=False,
                 qnetd_hostname=None,
                 quiet=False)
 


### PR DESCRIPTION
The --no-overwrite-sshkey is deprecated. There are 2 commits in this PR, but only the last is relevant. The first commit will disappear when #74 is merged.

Jira reference: https://jira.suse.com/browse/TEAM-894