### PR TITLE
Enable the test job in the ci for PRs

### DIFF
--- a/.github/workflows/salt-shaptools-ci.yml
+++ b/.github/workflows/salt-shaptools-ci.yml
@@ -11,7 +11,6 @@ jobs:
 
   test:
     runs-on: ubuntu-18.04
-    if: ${{ github.event_name != 'pull_request' }} 
     strategy:
      matrix:
       os: [ubuntu-18.04]
@@ -21,9 +20,9 @@ jobs:
       with:
         fetch-depth: 0
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2  
+      uses: actions/setup-python@v2
       with:
-        python-version: ${{ matrix.python-version }}   
+        python-version: ${{ matrix.python-version }}
     - name:  Install dependencies
       run: |
         python -m pip install --upgrade pip
@@ -34,7 +33,7 @@ jobs:
         git clone --depth=50 https://github.com/SUSE/shaptools.git ../shaptools
         pip install -e ../salt
         pip install ../shaptools
-    - name: execute test script   
+    - name: execute test script
       run: ./tests/run.sh
     - name: change absolute path to relative path for successful upload to code climate
       run: |
@@ -42,31 +41,31 @@ jobs:
         sed -i "s#$WORKSPACE##g" coverage.xml
     - name: Publish code coverage
       uses: paambaati/codeclimate-action@v2.7.5
-      if: env.CC_TEST_REPORTER_ID != null
+      if: ${{ env.CC_TEST_REPORTER_ID != null && github.event_name != 'pull_request' }}
       env:
         CC_TEST_REPORTER_ID: ${{ secrets.CC_TEST_REPORTER_ID }}
       with:
         coverageLocations: coverage.xml:coverage.py
- 
+
 
   delivery:
     needs: [test]
     runs-on: ubuntu-18.04
     if: ${{ github.event_name != 'pull_request' }}
-    container: 
+    container:
       image: shap/continuous_deliver
       env:
         OBS_USER: ${{ secrets.OBS_USER }}
         OBS_PASS: ${{ secrets.OBS_PASS }}
         OBS_PROJECT: ${{ secrets.OBS_PROJECT }}
     steps:
-    - uses: actions/checkout@v2 
+    - uses: actions/checkout@v2
       with:
         fetch-depth: 0
-    - name: configure OSC  
+    - name: configure OSC
     # OSC credentials must be configured beforehand as the HOME variables cannot be changed from /github/home
-    # that is used to run osc commands 
-      run: | 
+    # that is used to run osc commands
+      run: |
         /scripts/init_osc_creds.sh
         mkdir -p $HOME/.config/osc
         cp /root/.config/osc/oscrc $HOME/.config/osc
@@ -74,13 +73,13 @@ jobs:
       run: |
         sed -i 's~%%VERSION%%~${{ github.sha }}~' _service && \
         sed -i 's~%%REPOSITORY%%~${{ github.repository }}~' _service && \
-        /scripts/upload.sh 
+        /scripts/upload.sh
 
 
   submit:
     needs: [test, delivery]
     runs-on: ubuntu-18.04
-    if: ${{ github.event_name != 'pull_request' && github.ref == 'refs/heads/master' }}    
+    if: ${{ github.event_name != 'pull_request' && github.ref == 'refs/heads/master' }}
     container:
       image: shap/continuous_deliver
       env:
@@ -94,8 +93,8 @@ jobs:
         fetch-depth: 0
     - name: configure OSC
     # OSC credentials must be configured beforehand as the HOME variables cannot be changed from /github/home
-    # that is used to run osc commands 
-      run: | 
+    # that is used to run osc commands
+      run: |
         /scripts/init_osc_creds.sh
         mkdir -p $HOME/.config/osc
         cp /root/.config/osc/oscrc $HOME/.config/osc


### PR DESCRIPTION
The `test` job is disabled in the PRs, which is an error.
This change enables the test (but the codeclimate upload only works out of PRs as expected)

Needed by: https://github.com/SUSE/salt-shaptools/pull/80