### PR TITLE
add module to query remote HANA

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ Your directory layout should looks like ( all the 3 dirs are in same three dir l
 ```bash
 virtualenv saltvirtenv
 source saltvirtenv/bin/activate
-pip install pyzmq PyYAML pycrypto msgpack-python jinja2 psutil futures tornado pytest-salt mock pytest-cov
+pip install pyzmq PyYAML pycrypto msgpack-python jinja2 psutil futures tornado pytest-salt-factories mock pytest-cov
 pip install -e ../salt
 pip install -e ../shaptools
 rm ../salt/tests/conftest.py # remove this file from the saltstack repo
@@ -115,9 +115,7 @@ salt-call --local state.single saptune.solution_applied "HANA"
 
 ## Dependencies
 
-List of dependencies are specified in the ["Requirements file"](requirements.txt). Items can be installed using pip:
-
-    pip install -r requirements.txt
+A list of dependencies is named above in the `pip install ...` commands.
 
 ## License
 

--- a/_service
+++ b/_service
@@ -4,7 +4,7 @@
     <param name="scm">git</param>
     <param name="exclude">.git</param>
     <param name="filename">salt-shaptools</param>
-    <param name="versionformat">0.3.12+git.%ct.%h</param>
+    <param name="versionformat">0.3.13+git.%ct.%h</param>
     <param name="revision">%%VERSION%%</param>
   </service>
 

--- a/salt-shaptools.changes
+++ b/salt-shaptools.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Thu Jan 20 13:37:10 UTC 2022 - Eike Waldt <waldt@b1-systems.de>
+
+- Version 0.3.13
+  * Add module query to HANA
+
+-------------------------------------------------------------------
 Wed Jul 21 07:55:12 UTC 2021 - Eike Waldt <waldt@b1-systems.de>
 
 - Version 0.3.12

--- a/salt/modules/hanamod.py
+++ b/salt/modules/hanamod.py
@@ -948,21 +948,19 @@ def query(
 
     .. code-block:: bash
 
-        salt '*' hana.query 192.168.10.15 30015 SYSTEM pass
+        salt '*' hana.query 192.168.10.15 30015 SYSTEM pass 'SELECT * FROM SCHEMAS'
     '''
 
     connector = hdb_connector.HdbConnector()
     try:
         connector.connect(host, port, user=user, password=password)
-        rows = connector.query(query)
-        connector.disconnect()
-        # query is returned as a List, so we need to join it into a string
-        result = '\n'.join([str(row) for row in rows.records])
-        return result
+        result = connector.query(query)
 
     except base_connector.QueryError:
         raise exceptions.CommandExecutionError('HANA database query not successfull on {}:{} with query "{}"'.format(
                 host, port, query))
+    finally:
+        connector.disconnect()
 
 
 def reload_hdb_connector():  # pragma: no cover

--- a/salt/modules/hanamod.py
+++ b/salt/modules/hanamod.py
@@ -924,6 +924,47 @@ def wait_for_connection(
             ))
 
 
+def query(
+        host,
+        port,
+        user,
+        password,
+        query):
+    '''
+    Execute a query on a HANA database
+
+    host
+        Host where HANA is running
+    port
+        HANA database port
+    user
+        User to connect to the databse
+    password
+        Password to connect to the database
+    query
+        Query to execute on database
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' hana.query 192.168.10.15 30015 SYSTEM pass
+    '''
+
+    connector = hdb_connector.HdbConnector()
+    try:
+        connector.connect(host, port, user=user, password=password)
+        rows = connector.query(query)
+        connector.disconnect()
+        # query is returned as a List, so we need to join it into a string
+        result = '\n'.join([str(row) for row in rows.records])
+        return result
+
+    except base_connector.QueryError:
+        raise exceptions.CommandExecutionError('HANA database query not successfull on {}:{} with query "{}"'.format(
+                host, port, query))
+
+
 def reload_hdb_connector():  # pragma: no cover
     '''
     As hdb_connector uses pyhdb or dbapi, if these packages are installed on the fly,


### PR DESCRIPTION
This adds a module to query a remote HANA DB.  This let's us interact with the HANA from e.g. a S/4HANA PAS server.

It adds countless new possibilities.
- execute backups on a remote HANA--> https://github.com/SUSE/ha-sap-terraform-deployments/issues/803
- setting (persistent) DB settings remotely
- query HANA status or information remotely

It needs https://github.com/SUSE/shaptools/pull/69 to be fixed to work.