### PR TITLE
do not raise exception on empty HANA query results

### DIFF
--- a/_service
+++ b/_service
@@ -4,7 +4,7 @@
     <param name="scm">git</param>
     <param name="exclude">.git</param>
     <param name="filename">salt-shaptools</param>
-    <param name="versionformat">0.3.13+git.%ct.%h</param>
+    <param name="versionformat">0.3.14+git.%ct.%h</param>
     <param name="revision">%%VERSION%%</param>
   </service>
 

--- a/salt-shaptools.changes
+++ b/salt-shaptools.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Wed Feb  2 16:36:27 UTC 2022 - Eike Waldt <waldt@b1-systems.de>
+
+- Version 0.3.14
+  * do not raise exception on empty HANA query results
+
+-------------------------------------------------------------------
 Thu Jan 20 13:37:10 UTC 2022 - Eike Waldt <waldt@b1-systems.de>
 
 - Version 0.3.13

--- a/salt/modules/hanamod.py
+++ b/salt/modules/hanamod.py
@@ -956,9 +956,15 @@ def query(
         connector.connect(host, port, user=user, password=password)
         result = connector.query(query)
 
-    except base_connector.QueryError:
-        raise exceptions.CommandExecutionError('HANA database query not successfull on {}:{} with query "{}"'.format(
-                host, port, query))
+    except base_connector.QueryError as err:
+        if str(err) == "query failed: (0, 'No result set')":
+            pass # This is not error, but an empty query result.
+        else:
+            raise exceptions.CommandExecutionError(
+                'HANA database query not successfull on {}:{} with query "{}"'.format(
+                    host, port, query
+                )
+            )
     finally:
         connector.disconnect()
 

--- a/tests/unit/modules/test_hanamod.py
+++ b/tests/unit/modules/test_hanamod.py
@@ -843,6 +843,20 @@ class HanaModuleTest(TestCase, LoaderModuleMockMixin):
                 '192.168.10.15', '30015', 'query')) in str(err.value)
         mock_hdb_instance.disconnect.assert_called_once_with()
 
+    @mock.patch('salt.modules.hanamod.hdb_connector.HdbConnector')
+    def test_query_result_empty(self, mock_hdb_connector):
+        mock_hdb_instance = mock.Mock()
+        mock_hdb_connector.return_value = mock_hdb_instance
+
+        mock_hdb_instance.query.side_effect = hanamod.base_connector.QueryError("query failed: (0, 'No result set')")
+        hanamod.query(
+            '192.168.10.15', 30015, 'SYSTEM', 'pass', 'query')
+
+        mock_hdb_instance.connect.assert_called_once_with(
+            '192.168.10.15', 30015, user='SYSTEM', password='pass')
+        mock_hdb_instance.query.assert_called_once_with('query')
+        mock_hdb_instance.disconnect.assert_called_once_with()
+
     @mock.patch('salt.modules.hanamod.hdb_connector')
     @mock.patch('salt.modules.hanamod.reload_module')
     def test_reload_hdb_connector_py3(self, mock_reload, mock_hdb_connector):


### PR DESCRIPTION
This is a follow up on the discussions in https://github.com/SUSE/shaptools/pull/69

If you run the HANA query module and you get empty results, this will be thrown at the moment.

```
     An exception occurred in this state: Traceback (most recent call last):
                File "/usr/lib/python3.6/site-packages/shaptools/hdb_connector/connectors/dbapi_connector.py", line 70, in query
                  result = base_connector.QueryResult.load_cursor(cursor)
                File "/usr/lib/python3.6/site-packages/shaptools/hdb_connector/connectors/base_connector.py", line 61, in load_cursor
                  records = cursor.fetchall() # TODO: catch any exceptions raised by fetchall()
              hdbcli.dbapi.ProgrammingError: (0, 'No result set')

              During handling of the above exception, another exception occurred:

              Traceback (most recent call last):
                File "/var/cache/salt/minion/extmods/modules/hanamod.py", line 993, in query
                  connector.query(query)
                File "/usr/lib/python3.6/site-packages/shaptools/hdb_connector/connectors/dbapi_connector.py", line 78, in query
                  raise base_connector.QueryError('query failed: {}'.format(err))
              shaptools.hdb_connector.connectors.base_connector.QueryError: query failed: (0, 'No result set')

              During handling of the above exception, another exception occurred:

              Traceback (most recent call last):
                File "/usr/lib/python3.6/site-packages/salt/state.py", line 2187, in call
                  *cdata["args"], **cdata["kwargs"]
                File "/usr/lib/python3.6/site-packages/salt/loader.py", line 2113, in wrapper
                  return f(*args, **kwargs)
                File "/usr/lib/python3.6/site-packages/salt/utils/decorators/__init__.py", line 738, in _decorate
                  return self._call_function(kwargs)
                File "/usr/lib/python3.6/site-packages/salt/utils/decorators/__init__.py", line 352, in _call_function
                  return self._function(*args, **kwargs)
                File "/usr/lib/python3.6/site-packages/salt/states/module.py", line 422, in run
                  _func, returner=kwargs.get("returner"), func_args=kwargs.get(func)
                File "/usr/lib/python3.6/site-packages/salt/states/module.py", line 467, in _call_function
                  mret = salt.utils.functools.call_function(__salt__[name], *func_args, **func_kwargs)
                File "/usr/lib/python3.6/site-packages/salt/utils/functools.py", line 159, in call_function
                  return salt_function(*function_args, **function_kwargs)
                File "/var/cache/salt/minion/extmods/modules/hanamod.py", line 1000, in query
                  host, port, query ))
              salt.exceptions.CommandExecutionError: HANA database query not successfull on 10.0.0.12:30013 with query " ALTER SYSTEM RECONFIGURE SERVICE ('','',0)"
```

We do not want an exception when there is an empty query result.