### PR TITLE
add HANA add_hosts feature

### DIFF
--- a/_service
+++ b/_service
@@ -4,7 +4,7 @@
     <param name="scm">git</param>
     <param name="exclude">.git</param>
     <param name="filename">salt-shaptools</param>
-    <param name="versionformat">0.3.16+git.%ct.%h</param>
+    <param name="versionformat">0.3.17+git.%ct.%h</param>
     <param name="revision">%%VERSION%%</param>
   </service>
 

--- a/salt-shaptools.changes
+++ b/salt-shaptools.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Fri Apr 28 08:55:32 UTC 2022 - Eike Waldt <waldt@b1-systems.de>
+
+- Version 0.3.17
+  * add HANA add_hosts feature
+
+-------------------------------------------------------------------
 Fri Apr 19 14:04:54 UTC 2022 - Eike Waldt <waldt@b1-systems.de>
 
 - Version 0.3.16

--- a/salt/modules/hanamod.py
+++ b/salt/modules/hanamod.py
@@ -239,6 +239,36 @@ def install(
     except hana.HanaError as err:
         raise exceptions.CommandExecutionError(err)
 
+def add_hosts(
+        add_hosts,
+        hdblcm_folder,
+        root_user,
+        root_password,
+        hdb_pwd_file):
+    '''
+    Add additional hosts to SAP HANA system
+
+    add_hosts
+        hosts to add (same format as in hdblcm config)
+    hdblcm_folder
+        Path where hdblcm is installed
+    root_user
+        Root user name
+    root_password
+        Root user password
+    hdb_pwd_file
+        Path where XML password file exists
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' hana.add_hosts hana03:role=standby,hana05:role=worker /hana/shared/SID/hdblcm root root /root/hdb_passwords.xml
+    '''
+    try:
+        hana.HanaInstance.add_hosts(
+            add_hosts, hdblcm_folder, root_user, root_password, hdb_pwd_file)
+    except hana.HanaError as err:
+        raise exceptions.CommandExecutionError(err)
 
 def uninstall(
         root_user,

--- a/tests/unit/modules/test_hanamod.py
+++ b/tests/unit/modules/test_hanamod.py
@@ -202,6 +202,32 @@ class HanaModuleTest(TestCase, LoaderModuleMockMixin):
             'software_path', 'hana.conf', 'root', 'root', 'hana.conf.xml')
         assert 'hana error' in str(err.value)
 
+    @patch('salt.modules.hanamod.hana.HanaInstance')
+    def test_add_hosts_return(self, mock_hana):
+        '''
+        Test add_hosts method - return
+        '''
+        mock_hana.add_hosts.return_value = 'hana.conf'
+        hanamod.add_hosts(
+            'add_hosts', 'hdblcm_folder', 'root', 'root', 'hdb_pwd_file')
+        mock_hana.add_hosts.assert_called_once_with(
+            'add_hosts', 'hdblcm_folder', 'root', 'root', 'hdb_pwd_file')
+
+    @patch('salt.modules.hanamod.hana.HanaInstance')
+    def test_add_hosts_raise(self, mock_hana):
+        '''
+        Test add_hosts method - raise
+        '''
+        mock_hana.add_hosts.side_effect = hanamod.hana.HanaError(
+            'hana error'
+        )
+        with pytest.raises(exceptions.CommandExecutionError) as err:
+            hanamod.add_hosts(
+                'add_hosts', 'hdblcm_folder', 'root', 'root', 'hdb_pwd_file')
+        mock_hana.add_hosts.assert_called_once_with(
+            'add_hosts', 'hdblcm_folder', 'root', 'root', 'hdb_pwd_file')
+        assert 'hana error' in str(err.value)
+
     def test_uninstall_return(self):
         '''
         Test uninstall method - return


### PR DESCRIPTION
- Add feature to run `hdblcm -action=add_hosts`. This can be used to deploy scale-out scenarios.
- needs code changes from https://github.com/SUSE/shaptools/pull/70