### PR TITLE
store crm state in __context__ instead of __salt__

### DIFF
--- a/_service
+++ b/_service
@@ -4,7 +4,7 @@
     <param name="scm">git</param>
     <param name="exclude">.git</param>
     <param name="filename">salt-shaptools</param>
-    <param name="versionformat">0.3.15+git.%ct.%h</param>
+    <param name="versionformat">0.3.16+git.%ct.%h</param>
     <param name="revision">%%VERSION%%</param>
   </service>
 

--- a/salt-shaptools.changes
+++ b/salt-shaptools.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Fri Apr 19 14:04:54 UTC 2022 - Eike Waldt <waldt@b1-systems.de>
+
+- Version 0.3.16
+  * store crm state in __context__ instead of __salt__
+
+-------------------------------------------------------------------
 Fri Mar 18 15:02:13 UTC 2022 - Eike Waldt <waldt@b1-systems.de>
 
 - Version 0.3.15

--- a/salt/modules/crmshmod.py
+++ b/salt/modules/crmshmod.py
@@ -64,8 +64,8 @@ def __virtual__():
             'The crmsh execution module failed to load: the ha-cluster-init'
             ' package is not available.')
 
-    __salt__['crm.version'] = version
-    __salt__['crm.use_crm'] = use_crm
+    __context__['crm.version'] = version
+    __context__['crm.use_crm'] = use_crm
     return __virtualname__
 
 
@@ -446,8 +446,8 @@ def cluster_init(
         ocfs2_dev = [ocfs2_dev]
 
     # INFO: 2 different methods are created to make easy to read/understand
-    # and create the corresponing UT
-    if __salt__['crm.use_crm']:
+    # and create the corresponding UT
+    if __context__['crm.use_crm']:
         return _crm_init(
             name, watchdog, interface, unicast, admin_ip, sbd, sbd_dev, no_overwrite_sshkey,
             qnetd_hostname, quiet, ocfs2_dev, ocfs2_mount)
@@ -535,8 +535,8 @@ def cluster_join(
         salt '*' crm.cluster_join 192.168.1.41
     '''
     # INFO: 2 different methods are created to make easy to read/understand
-    # and create the corresponing UT
-    if __salt__['crm.use_crm']:
+    # and create the corresponding UT
+    if __context__['crm.use_crm']:
         return _crm_join(host, watchdog, interface, quiet)
 
     return _ha_cluster_join(host, watchdog, interface, quiet)
@@ -699,7 +699,7 @@ def detect_cloud():
     * google-cloud-platform
     * None (as string)(otherwise)
     '''
-    if int(__salt__['crm.version'][0]) <= 3:
+    if int(__context__['crm.version'][0]) <= 3:
         version = 'python'
     else:
         version = 'python3'

--- a/tests/unit/modules/test_crmshmod.py
+++ b/tests/unit/modules/test_crmshmod.py
@@ -448,7 +448,7 @@ class CrmshModuleTest(TestCase, LoaderModuleMockMixin):
         Test cluster_init with crm option
         '''
 
-        with patch.dict(crmshmod.__salt__, {'crm.use_crm': True}):
+        with patch.dict(crmshmod.__context__, {'crm.use_crm': True}):
             crm_init.return_value = 0
             value = crmshmod.cluster_init('hacluster', 'dog', 'eth1', sbd=True, sbd_dev='dev1')
             assert value == 0
@@ -456,7 +456,7 @@ class CrmshModuleTest(TestCase, LoaderModuleMockMixin):
                 'hacluster', 'dog', 'eth1', None, None, True, ['dev1'], False, None, None, None, None)
 
         crm_init.reset_mock()
-        with patch.dict(crmshmod.__salt__, {'crm.use_crm': True}):
+        with patch.dict(crmshmod.__context__, {'crm.use_crm': True}):
             crm_init.return_value = 0
             value = crmshmod.cluster_init('hacluster', 'dog', 'eth1', sbd=False, sbd_dev=['disk1', 'disk2'], ocfs2_dev='disk3', ocfs2_mount='mount')
             assert value == 0
@@ -470,7 +470,7 @@ class CrmshModuleTest(TestCase, LoaderModuleMockMixin):
         Test cluster_init with ha_cluster_init option
         '''
 
-        with patch.dict(crmshmod.__salt__, {'crm.use_crm': False}):
+        with patch.dict(crmshmod.__context__, {'crm.use_crm': False}):
             ha_cluster_init.return_value = 0
             value = crmshmod.cluster_init(
                 'hacluster', 'dog', 'eth1', sbd_dev='dev1', no_overwrite_sshkey=True)
@@ -567,7 +567,7 @@ class CrmshModuleTest(TestCase, LoaderModuleMockMixin):
         '''
         Test cluster_join with crm option
         '''
-        with patch.dict(crmshmod.__salt__, {'crm.use_crm': True}):
+        with patch.dict(crmshmod.__context__, {'crm.use_crm': True}):
             crm_join.return_value = 0
             value = crmshmod.cluster_join('host', 'dog', 'eth1')
             assert value == 0
@@ -579,7 +579,7 @@ class CrmshModuleTest(TestCase, LoaderModuleMockMixin):
         '''
         Test cluster_join with ha_cluster_join option
         '''
-        with patch.dict(crmshmod.__salt__, {'crm.use_crm': False}):
+        with patch.dict(crmshmod.__context__, {'crm.use_crm': False}):
             ha_cluster_join.return_value = 0
             value = crmshmod.cluster_join('host', 'dog', 'eth1')
             assert value == 0
@@ -759,11 +759,10 @@ class CrmshModuleTest(TestCase, LoaderModuleMockMixin):
         mock_versin = '3.0.0'
         mock_cmd_run = MagicMock(return_value='my-cloud ')
 
-        with patch.dict(crmshmod.__salt__, {
-                'crm.version': mock_versin,
-                'cmd.run': mock_cmd_run}):
-            result = crmshmod.detect_cloud()
-            assert result == 'my-cloud'
+        with patch.dict(crmshmod.__context__, {'crm.version': mock_versin}):
+            with patch.dict(crmshmod.__salt__, {'cmd.run': mock_cmd_run}):
+                result = crmshmod.detect_cloud()
+                assert result == 'my-cloud'
 
         mock_cmd_run.assert_called_once_with(
             'python -c "from crmsh import utils; print(utils.detect_cloud());"')
@@ -775,11 +774,10 @@ class CrmshModuleTest(TestCase, LoaderModuleMockMixin):
         mock_versin = '4.0.0'
         mock_cmd_run = MagicMock(return_value='my-cloud ')
 
-        with patch.dict(crmshmod.__salt__, {
-                'crm.version': mock_versin,
-                'cmd.run': mock_cmd_run}):
-            result = crmshmod.detect_cloud()
-            assert result == 'my-cloud'
+        with patch.dict(crmshmod.__context__, {'crm.version': mock_versin}):
+            with patch.dict(crmshmod.__salt__, {'cmd.run': mock_cmd_run}):
+                result = crmshmod.detect_cloud()
+                assert result == 'my-cloud'
 
         mock_cmd_run.assert_called_once_with(
             'python3 -c "from crmsh import utils; print(utils.detect_cloud());"')


### PR DESCRIPTION
Instead of using the "magic dunder" `__salt__`, this PR now makes use of `__context__`.
https://docs.saltproject.io/en/latest/topics/development/modules/developing.html#salt
https://docs.saltproject.io/en/latest/topics/development/modules/developing.html#context

This fixes #89 and makes the code run on `>= salt-3003` https://salt.tips/whats-new-in-salt-aluminium-release/#loader-contexts.