### PR TITLE
Salt no longer vendors six (>=salt-3006.0)

### DIFF
--- a/_service
+++ b/_service
@@ -4,7 +4,7 @@
     <param name="scm">git</param>
     <param name="exclude">.git</param>
     <param name="filename">salt-shaptools</param>
-    <param name="versionformat">0.3.17+git.%ct.%h</param>
+    <param name="versionformat">0.3.18+git.%ct.%h</param>
     <param name="revision">%%VERSION%%</param>
   </service>
 

--- a/salt-shaptools.changes
+++ b/salt-shaptools.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Tue Jul 11 15:03:17 UTC 2023 - Eike Waldt <waldt@b1-systems.de>
+
+- Version 0.3.18
+  * Salt no longer vendors six (>=salt-3006.0)
+    https://github.com/saltstack/salt/issues/63874
+
+-------------------------------------------------------------------
 Fri Apr 28 08:55:32 UTC 2022 - Eike Waldt <waldt@b1-systems.de>
 
 - Version 0.3.17

--- a/salt-shaptools.spec
+++ b/salt-shaptools.spec
@@ -28,6 +28,8 @@ URL:            https://github.com/SUSE/%{name}
 Source0:        %{name}-%{version}.tar.gz
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build
 BuildArch:      noarch
+BuildRequires:  python-rpm-macros
+Requires:       %{python_module six}
 
 %description
 Salt modules and states for SAP Applications and SLE-HA components management

--- a/salt/modules/drbdmod.py
+++ b/salt/modules/drbdmod.py
@@ -14,13 +14,20 @@ Module to provide DRBD functionality to Salt
 .. code-block:: yaml
 
 '''
+# Import python libs
 from __future__ import absolute_import, print_function, unicode_literals
-
 import logging
 
-from salt.exceptions import CommandExecutionError
-from salt.ext import six
+# Import six - Python 2 and 3 compatibility library
+# Salt no longer vendors six (>=salt-3006.0)
+# https://github.com/saltstack/salt/issues/63874
+try:
+    from salt.ext import six
+except ImportError:
+    import six
 
+# Import salt libs
+from salt.exceptions import CommandExecutionError
 import salt.utils.json
 import salt.utils.path
 

--- a/salt/modules/hanamod.py
+++ b/salt/modules/hanamod.py
@@ -32,7 +32,15 @@ import os
 if sys.version_info.major == 2: # pragma: no cover
     import imp
 
-from salt.ext.six.moves import reload_module
+# Import six - Python 2 and 3 compatibility library
+# Salt no longer vendors six (>=salt-3006.0)
+# https://github.com/saltstack/salt/issues/63874
+try:
+    from salt.ext.six.moves import reload_module
+except ImportError:
+    from six.moves import reload_module
+
+# Import salt libs
 from salt import exceptions
 from salt.utils import files as salt_files
 

--- a/salt/states/crmshmod.py
+++ b/salt/states/crmshmod.py
@@ -32,11 +32,17 @@ State module to provide CRMSH (HA cluster) functionality to Salt
 # Import python libs
 from __future__ import absolute_import, unicode_literals, print_function
 
+# Import six - Python 2 and 3 compatibility library
+# Salt no longer vendors six (>=salt-3006.0)
+# https://github.com/saltstack/salt/issues/63874
+try:
+    from salt.ext import six
+except ImportError:
+    import six
 
 # Import salt libs
 from salt import exceptions
 from salt import utils as salt_utils
-from salt.ext import six
 
 
 __virtualname__ = 'crm'

--- a/salt/states/drbdmod.py
+++ b/salt/states/drbdmod.py
@@ -36,12 +36,21 @@ State module to provide DRBD functionality to Salt
 .. code-block:: yaml
 
 '''
+# Import python libs
 from __future__ import absolute_import, print_function, unicode_literals
 import logging
 import time
 
+# Import six - Python 2 and 3 compatibility library
+# Salt no longer vendors six (>=salt-3006.0)
+# https://github.com/saltstack/salt/issues/63874
+try:
+    from salt.ext import six
+except ImportError:
+    import six
+
+# Import salt libs
 from salt.exceptions import CommandExecutionError
-from salt.ext import six
 
 LOGGER = logging.getLogger(__name__)
 

--- a/salt/states/hanamod.py
+++ b/salt/states/hanamod.py
@@ -58,10 +58,16 @@ State module to provide SAP HANA functionality to Salt
 # Import python libs
 from __future__ import absolute_import, unicode_literals, print_function
 
+# Import six - Python 2 and 3 compatibility library
+# Salt no longer vendors six (>=salt-3006.0)
+# https://github.com/saltstack/salt/issues/63874
+try:
+    from salt.ext import six
+except ImportError:
+    import six
 
 # Import salt libs
 from salt import exceptions
-from salt.ext import six
 
 
 __virtualname__ = 'hana'

--- a/salt/states/netweavermod.py
+++ b/salt/states/netweavermod.py
@@ -38,9 +38,16 @@ State module to provide SAP Netweaver functionality to Salt
 # Import python libs
 from __future__ import absolute_import, unicode_literals, print_function
 
+# Import six - Python 2 and 3 compatibility library
+# Salt no longer vendors six (>=salt-3006.0)
+# https://github.com/saltstack/salt/issues/63874
+try:
+    from salt.ext import six
+except ImportError:
+    import six
+
 # Import salt libs
 from salt import exceptions
-from salt.ext import six
 
 
 __virtualname__ = 'netweaver'

--- a/salt/states/sapcarmod.py
+++ b/salt/states/sapcarmod.py
@@ -25,9 +25,16 @@ State module to provide SAP utilities functionality to Salt
 # Import python libs
 from __future__ import absolute_import, unicode_literals
 
+# Import six - Python 2 and 3 compatibility library
+# Salt no longer vendors six (>=salt-3006.0)
+# https://github.com/saltstack/salt/issues/63874
+try:
+    from salt.ext import six
+except ImportError:
+    import six
+
 # Import salt libs
 from salt import exceptions
-from salt.ext import six
 
 
 __virtualname__ = 'sapcar'

--- a/salt/states/saptunemod.py
+++ b/salt/states/saptunemod.py
@@ -15,10 +15,16 @@ State module to provide Saptune functionality to Salt
 # Import python libs
 from __future__ import absolute_import, unicode_literals, print_function
 
+# Import six - Python 2 and 3 compatibility library
+# Salt no longer vendors six (>=salt-3006.0)
+# https://github.com/saltstack/salt/issues/63874
+try:
+    from salt.ext import six
+except ImportError:
+    import six
 
 # Import salt libs
 from salt import exceptions
-from salt.ext import six
 
 
 __virtualname__ = 'saptune'


### PR DESCRIPTION
Salt no longer vendors six (>=salt-3006.0)
https://github.com/saltstack/salt/issues/63874

- Use shipped library with older salt releases and use packaged version in newer version.

This is related to https://github.com/SUSE/ha-sap-terraform-deployments/issues/908